### PR TITLE
Added option for developer to add Release versions. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blender Addon Updater
 
-With this python module, developers can create auto-checking for updates with their blender addons as well as one-click version installs. Updates are retrieved using GitHub's, GitLab's, or Bitbucket's code api, so the addon must have it's updated code available on GitHub/GitLab/Bitbucket and be making use of either GitHub tags or releases. 
+With this Python module, developers can create auto-checking for updates with their blender addons as well as one-click version installs. Updates are retrieved using GitHub's, GitLab's, or Bitbucket's code api, so the addon must have it's updated code available on GitHub/GitLab/Bitbucket and be making use of either GitHub tags or releases. 
 
 **This code is ready for production with public repositories, and for private use with GitLab repositories**
 
@@ -25,7 +25,7 @@ With this module, there are essentially 3 different configurations:
 - Connect an addon to GitHub that doesn't have any releases, and allow use to 1-click install to a default branch and select from other explicitly included branches to install (does not us any version checking, will alway pull the latest code even if the same)
 
 
-*Note the repository is not currently setup to be used with single python file addons, this must be used with a zip-installed addon. It also assumes the use of the user preferences panel dedicated to the addon.*
+*Note the repository is not currently setup to be used with single Python file addons, this must be used with a zip-installed addon. It also assumes the use of the user preferences panel dedicated to the addon.*
 
 # High level setup
 
@@ -35,7 +35,7 @@ This module works by utilizing git releases on a repository. When a [release](ht
 
 This repository contains a fully working example of an addon with the updater code, but to integrate into another or existing addon, only the `addon_updater.py` and `addon_updater_ops.py` files are needed. 
 
-`addon_updater.py` is an independent python module that is the brains of the updater. It is implemented as a singleton, so the module-level variables are the same wherever it is imported. This file should not need to be modified by a developer looking to integrate auto-updating into an addon. Local "private" variables starting with _ have corresponding @property interfaces for interacting with the singleton instance's variables.
+`addon_updater.py` is an independent Python module that is the brains of the updater. It is implemented as a singleton, so the module-level variables are the same wherever it is imported. This file should not need to be modified by a developer looking to integrate auto-updating into an addon. Local "private" variables starting with _ have corresponding @property interfaces for interacting with the singleton instance's variables.
 
 `addon_updater_ops.py` links the states and settings of the `addon_updater.py` module and displays the according interface. This file is expected to be modified accordingly to be integrated with into another addon, and serves mostly as a working example of how to implement the updater code. 
 
@@ -43,7 +43,7 @@ In this documentation, `addon_updater.py` is referred to by "the Python Module" 
 
 # About the example addon
 
-Included in this repository is an example addon which is integrates the auto-updater feature. It is currently linked to this repository and it's tags for testing. To use in your own addon, you only need the `addon_upder.py` and `addon_updater_ops.py` files. Then, you simply need to make the according function calls and create a release or tag on the corresponding GitHub repository.
+Included in this repository is an example addon which is integrates the auto-updater feature. It is currently linked to this repository and it's tags for testing. To use in your own addon, you only need the `addon_updater.py` and `addon_updater_ops.py` files. Then, you simply need to make the according function calls and create a release or tag on the corresponding GitHub repository.
 
 # Step-by-step as-is integration with existing addons
 

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -42,7 +42,7 @@ except Exception as e:
 # Must declare this before classes are loaded
 # otherwise the bl_idname's will not match and have errors.
 # Must be all lowercase and no spaces
-updater.addon = "addon_updater_demo"
+updater.addon = "theaforblender"
 
 
 # -----------------------------------------------------------------------------
@@ -67,6 +67,9 @@ class addon_updater_install_popup(bpy.types.Operator):
 		options={'HIDDEN'}
 	)
 
+	def check (self, context):
+		return True
+
 	def invoke(self, context, event):
 		return context.window_manager.invoke_props_dialog(self)
 
@@ -83,9 +86,9 @@ class addon_updater_install_popup(bpy.types.Operator):
 			col.label("or click outside window to defer",icon="BLANK1")
 			# could offer to remove popups here, but window will not redraw
 			# so may be confusing to the user/look like a bug
-			# row = layout.row()
-			# row.label("Prevent future popups:")
-			# row.operator(addon_updater_ignore.bl_idname,text="Ignore update")
+			row = layout.row()
+			row.label("Prevent future popups:")
+			row.operator(addon_updater_ignore.bl_idname,text="Ignore update")
 		elif updater.update_ready == False:
 			col = layout.column()
 			col.scale_y = 0.7
@@ -119,7 +122,7 @@ class addon_updater_install_popup(bpy.types.Operator):
 				else: print("Updater returned "+str(res)+", error occurred")
 		elif updater.update_ready == None:
 			(update_ready, version, link) = updater.check_for_update(now=True)
-			
+
 			# re-launch this dialog
 			atr = addon_updater_install_popup.bl_idname.split(".")
 			getattr(getattr(bpy.ops, atr[0]),atr[1])('INVOKE_DEFAULT')
@@ -154,8 +157,8 @@ class addon_updater_check_now(bpy.types.Operator):
 					days=settings.updater_intrval_days,
 					hours=settings.updater_intrval_hours,
 					minutes=settings.updater_intrval_minutes
-					) # optional, if auto_check_update 
-		
+					) # optional, if auto_check_update
+
 		# input is an optional callback function
 		# this function should take a bool input, if true: update ready
 		# if false, no update ready
@@ -208,7 +211,7 @@ class addon_updater_update_now(bpy.types.Operator):
 			# re-launch this dialog
 			atr = addon_updater_install_popup.bl_idname.split(".")
 			getattr(getattr(bpy.ops, atr[0]),atr[1])('INVOKE_DEFAULT')
-			
+
 		elif updater.update_ready == False:
 			self.report({'INFO'}, "Nothing to update")
 		else:
@@ -416,7 +419,7 @@ class addon_updater_updated_successful(bpy.types.Operator):
 				col.scale_y = 0.7
 				col.label("Addon successfully installed", icon="FILE_TICK")
 				col.label("Consider restarting blender to fully reload.", icon="BLANK1")
-	
+
 	def execut(self, context):
 		return {'FINISHED'}
 
@@ -433,7 +436,7 @@ class addon_updater_restore_backup(bpy.types.Operator):
 			return os.path.isdir(os.path.join(updater.stage_path,"backup"))
 		except:
 			return False
-	
+
 	def execute(self, context):
 		# in case of error importing updater
 		if updater.invalidupdater == True:
@@ -456,7 +459,7 @@ class addon_updater_ignore(bpy.types.Operator):
 			return True
 		else:
 			return False
-	
+
 	def execute(self, context):
 		# in case of error importing updater
 		if updater.invalidupdater == True:
@@ -478,7 +481,7 @@ class addon_updater_end_background(bpy.types.Operator):
 	# 		return True
 	# 	else:
 	# 		return False
-	
+
 	def execute(self, context):
 		# in case of error importing updater
 		if updater.invalidupdater == True:
@@ -496,7 +499,7 @@ class addon_updater_end_background(bpy.types.Operator):
 ran_autocheck_install_popup = False
 ran_update_sucess_popup = False
 
-# global var for preventing successive calls 
+# global var for preventing successive calls
 ran_background_check = False
 
 @persistent
@@ -542,7 +545,7 @@ def updater_run_install_popup_handler(scene):
 	elif "version_text" in updater.json and "version" in updater.json["version_text"]:
 		version = updater.json["version_text"]["version"]
 		ver_tuple = updater.version_tuple_from_text(version)
-		
+
 		if ver_tuple < updater.current_version:
 			# user probably manually installed to get the up to date addon
 			# in here. Clear out the update flag using this function
@@ -553,7 +556,7 @@ def updater_run_install_popup_handler(scene):
 			return
 	atr = addon_updater_install_popup.bl_idname.split(".")
 	getattr(getattr(bpy.ops, atr[0]),atr[1])('INVOKE_DEFAULT')
-	
+
 
 # passed into the updater, background thread updater
 def background_update_callback(update_ready):
@@ -565,13 +568,13 @@ def background_update_callback(update_ready):
 
 	if update_ready != True:
 		return
-	
+
 	if updater_run_install_popup_handler not in \
 				bpy.app.handlers.scene_update_post and \
 				ran_autocheck_install_popup==False:
 		bpy.app.handlers.scene_update_post.append(
 				updater_run_install_popup_handler)
-		
+
 		ran_autocheck_install_popup = True
 
 
@@ -616,7 +619,7 @@ def check_for_update_background():
 	elif updater.update_ready != None or updater.async_checking == True:
 		# Check already happened
 		# Used here to just avoid constant applying settings below
-		return 
+		return
 
 	# apply the UI settings
 	addon_prefs = bpy.context.user_preferences.addons.get(__package__, None)
@@ -628,8 +631,8 @@ def check_for_update_background():
 				days=settings.updater_intrval_days,
 				hours=settings.updater_intrval_hours,
 				minutes=settings.updater_intrval_minutes
-				) # optional, if auto_check_update 
-	
+				) # optional, if auto_check_update
+
 	# input is an optional callback function
 	# this function should take a bool input, if true: update ready
 	# if false, no update ready
@@ -656,7 +659,7 @@ def check_for_update_nonthreaded(self, context):
 				days=settings.updater_intrval_days,
 				hours=settings.updater_intrval_hours,
 				minutes=settings.updater_intrval_minutes
-				) # optional, if auto_check_update 
+				) # optional, if auto_check_update
 
 	(update_ready, version, link) = updater.check_for_update(now=False)
 	if update_ready == True:
@@ -685,11 +688,11 @@ def showReloadPopup():
 		updater.json_reset_postupdate() # so this only runs once
 
 		# no handlers in this case
-		if updater.auto_reload_post_update == False: return 
+		if updater.auto_reload_post_update == False: return
 
 		if updater_run_success_popup_handler not in \
 					bpy.app.handlers.scene_update_post \
-					and ran_update_sucess_popup==False:   
+					and ran_update_sucess_popup==False:
 			bpy.app.handlers.scene_update_post.append(
 					updater_run_success_popup_handler)
 			ran_update_sucess_popup = True
@@ -728,20 +731,25 @@ def update_notice_box_ui(self, context):
 	layout = self.layout
 	box = layout.box()
 	col = box.column(align=True)
-	
+	col.label("Update ready!",icon="ERROR")
+	col.separator()
+	row = col.row()
+	split = row.split()
+	colL = split.column(align=True)
+
+	colL.operator(addon_updater_ignore.bl_idname,icon="X")
+	colR = split.column(align=True)
+	col.separator()
 	if updater.manual_only==False:
-		col.label("Update ready!",icon="ERROR")
-		col.operator(addon_updater_update_now.bl_idname,
+		colR.operator(addon_updater_update_now.bl_idname,
 						"Update now", icon="LOOP_FORWARDS")
 		col.operator("wm.url_open", text="Open website").url = updater.website
 		#col.operator("wm.url_open",text="Direct download").url=updater.update_link
 		col.operator(addon_updater_install_manually.bl_idname, "Install manually")
 	else:
-		col.label("Update ready!",icon="ERROR")
 		#col.operator("wm.url_open",text="Direct download").url=updater.update_link
 		col.operator("wm.url_open", text="Get it now").url = \
 				updater.website
-	col.operator(addon_updater_ignore.bl_idname,icon="X")
 
 
 
@@ -823,7 +831,7 @@ def update_settings_ui(self, context):
 		split.scale_y = 2
 		split.operator(addon_updater_end_background.bl_idname,
 						text = "", icon="X")
-		
+
 	elif updater.include_branches==True and \
 			len(updater.tags)==len(updater.include_branch_list) and \
 			updater.manual_only==False:
@@ -903,10 +911,10 @@ def update_settings_ui(self, context):
 
 
 # a global function for tag skipping
-# a way to filter which tags are displayed, 
+# a way to filter which tags are displayed,
 # e.g. to limit downgrading too far
 # input is a tag text, e.g. "v1.2.3"
-# output is True for skipping this tag number, 
+# output is True for skipping this tag number,
 # False if the tag is allowed (default for all)
 # Note: here, "self" is the acting updater shared class instance
 def skip_tag_function(self, tag):
@@ -929,17 +937,17 @@ def skip_tag_function(self, tag):
 	# function converting string to tuple, ignoring e.g. leading 'v'
 	tupled = self.version_tuple_from_text(tag["name"])
 	if type(tupled) != type( (1,2,3) ): return True
-	
+
 	# select the min tag version - change tuple accordingly
 	if self.version_min_update != None:
 		if tupled < self.version_min_update:
 			return True # skip if current version below this
-	
+
 	# select the max tag version
 	if self.version_max_update != None:
 		if tupled >= self.version_max_update:
 			return True # skip if current version at or above this
-	
+
 	# in all other cases, allow showing the tag for updating/reverting
 	return False
 
@@ -968,24 +976,24 @@ def register(bl_info):
 	updater.private_token = None # "tokenstring"
 
 	# choose your own username, must match website (not needed for GitLab)
-	updater.user = "cgcookie"
+	updater.user = "schroef"
 
 	# choose your own repository, must match git name
-	updater.repo = "blender-addon-updater"
+	updater.repo = "TheaForBlender"
 
 	#updater.addon = # define at top of module, MUST be done first
 
 	# Website for manual addon download, optional but recommended to set
-	updater.website = "https://github.com/CGCookie/blender-addon-updater/"
-	
+	updater.website = "https://github.com/schroef/theaforblender/releases/"
+
 	# used to check/compare versions
-	updater.current_version = bl_info["version"] 
+	updater.current_version = bl_info["version"]
 
 	# Optional, to hard-set update frequency, use this here - however,
-	# this demo has this set via UI properties. 
+	# this demo has this set via UI properties.
 	# updater.set_check_interval(
 	# 		enable=False,months=0,days=0,hours=0,minutes=2)
-	
+
 	# Optional, consider turning off for production or allow as an option
 	# This will print out additional debugging info to the console
 	updater.verbose = True # make False for production default
@@ -1008,12 +1016,12 @@ def register(bl_info):
 	# Patterns for files to actively overwrite if found in new update
 	# file and are also found in the currently installed addon. Note that
 	# by default, updates are installed in the same wave as blender: .py
-	# files are replaced, but other file types (e.g. json, txt, blend) 
+	# files are replaced, but other file types (e.g. json, txt, blend)
 	# will NOT be overwritten if already present in current install. Thus
 	# if you want to automatically update resources/non py files, add them
 	# as a part of the pattern list below so they will always be overwritten
 	# If a pattern file is not found in new update, no action is taken
-	updater.overwrite_patterns = ["*.png","README.md","LICENSE.txt"]
+	updater.overwrite_patterns = ["*.png","README.md","LICENSE.txt","*.jpg","*.png","*.txt","*.ini"]
 	# updater.overwrite_patterns = []
 	# other examples:
 	# ["*"] means ALL files/folders will be overwritten by update, was the behavior pre updater v1.0.4
@@ -1042,12 +1050,17 @@ def register(bl_info):
 	# Allow branches like 'master' as an option to update to, regardless
 	# of release or version.
 	# Default behavior: releases will still be used for auto check (popup),
-	# but the user has the option from user preferences to directly 
+	# but the user has the option from user preferences to directly
 	# update to the master branch or any other branches specified using
 	# the "install {branch}/older version" operator.
 	updater.include_branches = True
 
-	# if using "include_branches", 
+	# This options allows the user to install the release zips.
+	# This makes the updates smaller as it doesnt need to download the complete repo,
+	# with all possible other files. This is one of the cleanest installs
+	updater.include_releases = True
+
+	# if using "include_branches",
 	# updater.include_branch_list defaults to ['master'] branch if set to none
 	# example targeting another multiple branches allowed to pull from
 	# updater.include_branch_list = ['master', 'dev'] # example with two branches
@@ -1068,13 +1081,13 @@ def register(bl_info):
 	# Set the min and max versions allowed to install.
 	# Optional, default None
 	# min install (>=) will install this and higher
-	updater.version_min_update = (0,0,0) 
+	updater.version_min_update = (1,5,8,760,1455)
 	# updater.version_min_update = None  # if not wanting to define a min
-	
+
 	# max install (<) will install strictly anything lower
 	# updater.version_max_update = (9,9,9)
 	updater.version_max_update = None  # if not wanting to define a max
-	
+
 	updater.skip_tag = skip_tag_function # min and max used in this function
 
 	# The register line items for all operators/panels
@@ -1112,7 +1125,7 @@ def unregister():
 
 	global ran_autocheck_install_popup
 	ran_autocheck_install_popup = False
-	
+
 	global ran_update_sucess_popup
 	ran_update_sucess_popup = False
 


### PR DESCRIPTION
This will show the Title as version number. Using releases is much smaller as nothing of the repository itself is downloaded. These being readme.md, licenses and possible all other folders like image, wiki or any other folder. Thus makes the update faster and way smaller, also is much cleaner in the Blender addon folder after the update.

In the example below the release file 400Kb where as the complete branch repo is 5Mb. Much faster and cleaner!

Now it shows titles of the releases as well and downloads the much smaller zip files
![screen shot 2018-02-14 at 1 04 33 am](https://user-images.githubusercontent.com/6923008/36188552-21403c26-1123-11e8-9a6c-df0178b63455.png)


As how it shows in blender addon
![screen shot 2018-02-14 at 1 03 59 am](https://user-images.githubusercontent.com/6923008/36188525-f7f964d2-1122-11e8-9639-f10267154eb6.png)

