### PR TITLE
Fixed typo in definition name

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -454,7 +454,7 @@ class addon_updater_updated_successful(bpy.types.Operator):
 				col.label("Addon successfully installed", icon="FILE_TICK")
 				col.label("Consider restarting blender to fully reload.", icon="BLANK1")
 
-	def execut(self, context):
+	def execute(self, context):
 		return {'FINISHED'}
 
 


### PR DESCRIPTION
This removes the "* Redo Unsupported *" line from the popup after installing an update.
[Old popup](https://i.imgur.com/mjOnIji.png) vs [new popup](https://i.imgur.com/V8hQatS.png).