### PR TITLE
Use latest GitLab API version

### DIFF
--- a/addon_updater.py
+++ b/addon_updater.py
@@ -1459,7 +1459,7 @@ class GitlabEngine(object):
 		self.name = "gitlab"
 
 	def form_repo_url(self, updater):
-		return "{}{}{}".format(self.api_url,"/api/v3/projects/",updater.repo)
+		return "{}{}{}".format(self.api_url,"/api/v4/projects/",updater.repo)
 
 	def form_tags_url(self, updater):
 		return "{}{}".format(self.form_repo_url(updater),"/repository/tags")


### PR DESCRIPTION
Version 3 is no longer supported and gives a 404 error in
user preferences UI if GitLab is the selected engine.

This pull request may require more work if there are any important API changes to consider. I didn't dig into it at all, but here is GitLab's documentation on it:

https://docs.gitlab.com/ce/api/v3_to_v4.html
https://docs.gitlab.com/ee/api/v3_to_v4.html