### PR TITLE
Fix some files can't be overwrited by patterns

### DIFF
--- a/addon_updater.py
+++ b/addon_updater.py
@@ -1016,7 +1016,7 @@ class Singleton_updater(object):
 					# otherwise, check each file to see if matches an overwrite pattern
 					replaced=False
 					for ptrn in self._overwrite_patterns:
-						if fnmatch.filter([destFile],ptrn):
+						if fnmatch.filter([file],ptrn):
 							replaced=True
 							break
 					if replaced:


### PR DESCRIPTION
"desFile" is a full path of a file. It can't be filtered by a full name pattern of a file.

```python
# e.g.
fnmath.filter(["C:\\README.md"], "README.md") -> []
fnmath.filter(["C:\\README.md"], "*README.md") -> ["C:\\README.md"]
fnmath.filter(["README.md"], "README.md") -> ["README.md"]
```
