### PR TITLE
More verbose about errors

### DIFF
--- a/addon_updater.py
+++ b/addon_updater.py
@@ -169,7 +169,7 @@ class Singleton_updater(object):
 		try:
 			self._auto_reload_post_update = bool(value)
 		except:
-			raise ValueError("Must be a boolean value")
+			raise ValueError("auto_reload_post_update must be a boolean value")
 
 	@property
 	def backup_current(self):
@@ -354,7 +354,7 @@ class Singleton_updater(object):
 		try:
 			self._repo = str(value)
 		except:
-			raise ValueError("User must be a string")
+			raise ValueError("repo must be a string value")
 
 	@property
 	def select_link(self):

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -22,6 +22,7 @@ Implements draw calls, popups, and operators that use the addon_updater.
 """
 
 import os
+import traceback
 
 import bpy
 from bpy.app.handlers import persistent
@@ -33,10 +34,12 @@ try:
 except Exception as e:
 	print("ERROR INITIALIZING UPDATER")
 	print(str(e))
+	traceback.print_exc()
 	class Singleton_updater_none(object):
 		def __init__(self):
 			self.addon = None
 			self.verbose = False
+			self.print_traces = True
 			self.invalidupdater = True # used to distinguish bad install
 			self.error = None
 			self.error_msg = None
@@ -291,6 +294,7 @@ class addon_updater_update_now(bpy.types.Operator):
 			except Exception as e:
 				updater._error = "Error trying to run update"
 				updater._error_msg = str(e)
+				if updater.print_traces: traceback.print_exc()
 				atr = addon_updater_install_manually.bl_idname.split(".")
 				getattr(getattr(bpy.ops, atr[0]),atr[1])('INVOKE_DEFAULT')
 		elif updater.update_ready == None:

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -39,7 +39,7 @@ except Exception as e:
 		def __init__(self):
 			self.addon = None
 			self.verbose = False
-			self.print_traces = True
+			self.use_print_traces = True
 			self.invalidupdater = True # used to distinguish bad install
 			self.error = None
 			self.error_msg = None
@@ -294,7 +294,7 @@ class addon_updater_update_now(bpy.types.Operator):
 			except Exception as e:
 				updater._error = "Error trying to run update"
 				updater._error_msg = str(e)
-				if updater.print_traces: traceback.print_exc()
+				updater.print_trace()
 				atr = addon_updater_install_manually.bl_idname.split(".")
 				getattr(getattr(bpy.ops, atr[0]),atr[1])('INVOKE_DEFAULT')
 		elif updater.update_ready == None:


### PR DESCRIPTION
Should help figuring out #67

Fix a few error messages, and add `print_traces` to updater settings, similar to `verbose`.

Traces are only printed when `print_traces` is True, the default value is True

I think the default value being True makes sense because even in production you wouldn't want errors to be silently dropped and have no way of knowing what went wrong.