### PR TITLE
Formatting pep8

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Included in this repository is an example addon which is integrates the auto-upd
 
     ....
 
-    updater_intrval_minutes = bpy.props.IntProperty(
+    updater_interval_minutes = bpy.props.IntProperty(
         name='Minutes',
         description = "Number of minutes between checking for updates",
         default=0,
@@ -149,7 +149,7 @@ if updater.update_ready == True:
   if res == 0:
     print("Update ran successfully, restart blender")
   else:
-    print("Updater returned "+str(res)+", error occurred")
+    print("Updater returned " + str(res) + ", error occurred")
 elif updater.update_ready == False:
   print("No update available")
 elif updater.update_ready == None:
@@ -160,11 +160,11 @@ elif updater.update_ready == None:
 
 ```
 tag_version = updater.tags[2] # or otherwise select a valid tag
-res = updater.run_update(force=False,revert_tag=None, callback=function_obj)
+res = updater.run_update(force=False, revert_tag=None, callback=function_obj)
 if res == 0:
   print("Update ran successfully, restart blender")
 else:
-  print("Updater returned "+str(res)+", error occurred")
+  print("Updater returned " + str(res) + ", error occurred")
 ```
 
 
@@ -173,11 +173,11 @@ If utilizing updater.include_branches, you can grab the latest release tag by sk
 ```
 n = len(updater.include_branch_list)
 tag_version = updater.tags[n] # or otherwise select a valid tag
-res = updater.run_update(force=False,revert_tag=None, callback=function_obj)
+res = updater.run_update(force=False, revert_tag=None, callback=function_obj)
 if res == 0:
   print("Update ran successfully, restart blender")
 else:
-  print("Updater returned "+str(res)+", error occurred")
+  print("Updater returned " + str(res) + ", error occurred")
 ```
 
 
@@ -515,7 +515,7 @@ To accomplish the mentioned behavior, use the below configuration.
 
 ```
 updater.overwrite_patterns = ["README.md", "custom_icon.png"]
-updater.remove_pre_update_patterns = ["*.py","*.pyc", "default.blend"]
+updater.remove_pre_update_patterns = ["*.py", "*.pyc", "default.blend"]
 ```
 
 Breaking this down, we always specify to overwrite the README and custom_icon.png files explicitly. No need to remove either in pre update since we expect they will be found in the update, and the overwrite patterns ensures they always get overwritten and only those files.

--- a/__init__.py
+++ b/__init__.py
@@ -144,7 +144,7 @@ class DemoPreferences(bpy.types.AddonPreferences):
 
 classes = (
 	DemoPreferences,
-	OBJECT_PT_DemoUpdaterPanel
+	DemoUpdaterPanel
 )
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -156,7 +156,7 @@ def register():
 
 	# register the example panel, to show updater buttons
 	for cls in classes:
-		addon_updater_ops.make_annotations(cls) # to avoid blender 2.8 warnings
+		addon_updater_ops.make_annotations(cls)  # to avoid blender 2.8 warnings
 		bpy.utils.register_class(cls)
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -36,10 +36,10 @@ import bpy
 from . import addon_updater_ops
 
 
-class OBJECT_PT_DemoUpdaterPanel(bpy.types.Panel):
+class DemoUpdaterPanel(bpy.types.Panel):
 	"""Panel to demo popup notice and ignoring functionality"""
 	bl_label = "Updater Demo Panel"
-	bl_idname = "OBJECT_PT_hello"
+	bl_idname = "OBJECT_PT_DemoUpdaterPanel_hello"
 	bl_space_type = 'VIEW_3D'
 	bl_region_type = 'TOOLS' if bpy.app.version < (2, 80) else 'UI'
 	bl_context = "objectmode"
@@ -56,7 +56,6 @@ class OBJECT_PT_DemoUpdaterPanel(bpy.types.Panel):
 		# and if the time interval has passed
 		addon_updater_ops.check_for_update_background()
 
-
 		layout.label(text="Demo Updater Addon")
 		layout.label(text="")
 
@@ -68,7 +67,7 @@ class OBJECT_PT_DemoUpdaterPanel(bpy.types.Panel):
 
 		# could also use your own custom drawing
 		# based on shared variables
-		if addon_updater_ops.updater.update_ready == True:
+		if addon_updater_ops.updater.update_ready:
 			layout.label(text="Custom update message", icon="INFO")
 		layout.label(text="")
 
@@ -88,27 +87,31 @@ class DemoPreferences(bpy.types.AddonPreferences):
 		description="If enabled, auto-check for updates using an interval",
 		default=False,
 		)
-	updater_intrval_months = bpy.props.IntProperty(
+
+	updater_interval_months = bpy.props.IntProperty(
 		name='Months',
 		description="Number of months between checking for updates",
 		default=0,
 		min=0
 		)
-	updater_intrval_days = bpy.props.IntProperty(
+
+	updater_interval_days = bpy.props.IntProperty(
 		name='Days',
 		description="Number of days between checking for updates",
 		default=7,
 		min=0,
 		max=31
 		)
-	updater_intrval_hours = bpy.props.IntProperty(
+
+	updater_interval_hours = bpy.props.IntProperty(
 		name='Hours',
 		description="Number of hours between checking for updates",
 		default=0,
 		min=0,
 		max=23
 		)
-	updater_intrval_minutes = bpy.props.IntProperty(
+
+	updater_interval_minutes = bpy.props.IntProperty(
 		name='Minutes',
 		description="Number of minutes between checking for updates",
 		default=0,

--- a/__init__.py
+++ b/__init__.py
@@ -19,8 +19,8 @@
 bl_info = {
 	"name":        "Addon Updater Demo",
 	"description": "Demo addon for showcasing the blender-addon-updater module",
-	"author":      "Patrick W. Crawford",
-	"version":     (1, 0, 9),
+	"author":      "Patrick W. Crawford, neomonkeus",
+	"version":     (1, 1, 0),
 	"blender":     (2, 80, 0),
 	"location":    "View 3D > Tool Shelf > Demo Updater",
 	"warning":     "",  # used for warning icon and text in addons panel

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -763,7 +763,7 @@ class SingletonUpdater:
 
 		if error is not None:
 			if self._verbose:
-				print("Error: Aborting update, "+error)
+				print("Error: Aborting update, " + error)
 			self._error = "Update aborted, staging path error"
 			self._error_msg = "Error: {}".format(error)
 			return False
@@ -929,7 +929,7 @@ class SingletonUpdater:
 			top_folder = name[:name.index(zsep) + 1]
 			if name == top_folder + zsep:
 				continue  # skip top level folder
-			sub_path = name[name.index(zsep)+1:]
+			sub_path = name[name.index(zsep) + 1:]
 			if name.endswith(zsep):
 				try:
 					os.mkdir(os.path.join(outdir, sub_path))

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -20,7 +20,6 @@
 """
 See documentation for usage
 https://github.com/CGCookie/blender-addon-updater
-
 """
 
 __version__ = "1.0.10"
@@ -761,7 +760,8 @@ class Singleton_updater(object):
 				self.print_trace()
 
 		if error is not None:
-			if self._verbose: print("Error: Aborting update, "+error)
+			if self._verbose:
+				print("Error: Aborting update, "+error)
 			self._error = "Update aborted, staging path error"
 			self._error_msg = "Error: {}".format(error)
 			return False

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -65,9 +65,9 @@ class SingletonUpdater:
 		self._website = None
 		self._current_version = None
 		self._subfolder_path = None
-		self._tags = []
+		self._tags = list()
 		self._tag_latest = None
-		self._tag_names = []
+		self._tag_names = list()
 		self._latest_release = None
 		self._use_releases = False
 		self._include_branches = False
@@ -83,7 +83,7 @@ class SingletonUpdater:
 
 		# set patterns for what files to overwrite on update
 		self._overwrite_patterns = ["*.py", "*.pyc"]
-		self._remove_pre_update_patterns = []
+		self._remove_pre_update_patterns = list()
 
 		# by default, don't auto enable/disable the addon on update
 		# as it is slightly less stable/won't always fully reload module
@@ -415,7 +415,7 @@ class SingletonUpdater:
 	@property
 	def tags(self):
 		if len(self._tags) == 0:
-			return []
+			return list()
 		tag_names = list()
 		for tag in self._tags:
 			tag_names.append(tag["name"])
@@ -539,7 +539,7 @@ class SingletonUpdater:
 		return True
 
 	def _get_tag_names(self):
-		tag_names = []
+		tag_names = list()
 		self.get_tags()
 		for tag in self._tags:
 			tag_names.append(tag["name"])
@@ -603,7 +603,7 @@ class SingletonUpdater:
 			self._prefiltered_tag_count = len(all_tags)
 		else:
 			self._prefiltered_tag_count = 0
-			all_tags = []
+			all_tags = list()
 
 		# pre-process to skip tags
 		if self.skip_tag is not None:
@@ -627,7 +627,7 @@ class SingletonUpdater:
 		if self._tags is None:
 			# some error occurred
 			self._tag_latest = None
-			self._tags = []
+			self._tags = list()
 			return
 		elif self._prefiltered_tag_count == 0 and not self._include_branches:
 			self._tag_latest = None
@@ -1162,7 +1162,7 @@ class SingletonUpdater:
 
 		# should go through string and remove all non-integers,
 		# and for any given break split into a different section
-		segments = []
+		segments = list()
 		tmp = ''
 		for char in str(text):
 			if not char.isdigit():
@@ -1664,7 +1664,7 @@ class BitbucketEngine:
 
 	def parse_tags(self, response, updater):
 		if response is None:
-			return []
+			return list()
 		return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["name"], updater)} for tag in response["values"]]
 
 
@@ -1695,7 +1695,7 @@ class GithubEngine:
 
 	def parse_tags(self, response, updater):
 		if response is None:
-			return []
+			return list()
 		return response
 
 
@@ -1737,7 +1737,7 @@ class GitlabEngine:
 
 	def parse_tags(self, response, updater):
 		if response is None:
-			return []
+			return list()
 		return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["commit"]["id"], updater)} for tag in response]
 
 

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -72,7 +72,7 @@ class Singleton_updater(object):
 		self._use_releases = False
 		self._include_branches = False
 		self._include_branch_list = ['master']
-		self._include_branch_autocheck = False
+		self._include_branch_auto_check = False
 		self._manual_only = False
 		self._version_min_update = None
 		self._version_max_update = None
@@ -124,8 +124,8 @@ class Singleton_updater(object):
 		# properties to have
 
 		# to verify a valid import, in place of placeholder import
-		self.showpopups = True # used in UI to show or not show update popups
-		self.invalidupdater = False
+		self.show_popups = True  # used in UI to show or not show update popups
+		self.invalid_updater = False
 
 		# pre-assign basic select-link function
 		def select_link_function(self, tag):
@@ -265,12 +265,12 @@ class Singleton_updater(object):
 	# not currently used
 	@property
 	def include_branch_autocheck(self):
-		return self._include_branch_autocheck
+		return self._include_branch_auto_check
 
 	@include_branch_autocheck.setter
 	def include_branch_autocheck(self, value):
 		try:
-			self._include_branch_autocheck = bool(value)
+			self._include_branch_auto_check = bool(value)
 		except:
 			raise ValueError("include_branch_autocheck must be a boolean value")
 

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -115,7 +115,7 @@ class SingletonUpdater:
 		self._updater_path = os.path.join(os.path.dirname(__file__),
 										self._addon + "_updater")
 		self._addon_root = os.path.dirname(__file__)
-		self._json = {}
+		self._json = dict()
 		self._error = None
 		self._error_msg = None
 		self._prefiltered_tag_count = 0
@@ -1186,7 +1186,7 @@ class SingletonUpdater:
 	# called for running check in a background thread
 	def check_for_update_async(self, callback=None):
 
-		if self._json is not None and "update_ready" in self._json and self._json["version_text"] is not {}:
+		if self._json is not None and "update_ready" in self._json and self._json["version_text"] is not dict():
 			if self._json["update_ready"]:
 				self._update_ready = True
 				self._update_link = self._json["version_text"]["link"]
@@ -1369,7 +1369,7 @@ class SingletonUpdater:
 		"""
 		self._json["update_ready"] = False
 		self._json["ignore"] = False  # clear ignore flag
-		self._json["version_text"] = {}
+		self._json["version_text"] = dict()
 
 		if revert_tag is not None:
 			self.set_tag(revert_tag)
@@ -1526,7 +1526,7 @@ class SingletonUpdater:
 				"ignore": False,
 				"just_restored": False,
 				"just_updated": False,
-				"version_text": {}
+				"version_text": dict()
 			}
 			self.save_updater_json()
 
@@ -1539,10 +1539,10 @@ class SingletonUpdater:
 				self._json["version_text"]["version"] = self._update_version
 			else:
 				self._json["update_ready"] = False
-				self._json["version_text"] = {}
+				self._json["version_text"] = dict()
 		else:
 			self._json["update_ready"] = False
-			self._json["version_text"] = {}
+			self._json["version_text"] = dict()
 
 		jpath = self.get_json_path()
 		outf = open(jpath, 'w')
@@ -1556,13 +1556,13 @@ class SingletonUpdater:
 	def json_reset_postupdate(self):
 		self._json["just_updated"] = False
 		self._json["update_ready"] = False
-		self._json["version_text"] = {}
+		self._json["version_text"] = dict()
 		self.save_updater_json()
 
 	def json_reset_restore(self):
 		self._json["just_restored"] = False
 		self._json["update_ready"] = False
-		self._json["version_text"] = {}
+		self._json["version_text"] = dict()
 		self.save_updater_json()
 		self._update_ready = None  # reset so you could check update again
 

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -594,7 +594,8 @@ class SingletonUpdater:
 
 	def get_tags(self):
 		request = self.form_tags_url()
-		if self._verbose: print("Getting tags from server")
+		if self._verbose:
+			print("Getting tags from server")
 
 		# get all tags, internet call
 		all_tags = self._engine.parse_tags(self.get_api(request), self)
@@ -636,7 +637,8 @@ class SingletonUpdater:
 			if self._verbose:
 				print("No releases or tags found on this repository")
 		elif self._prefiltered_tag_count == 0 and self._include_branches:
-			if not self._error: self._tag_latest = self._tags[0]
+			if not self._error:
+				self._tag_latest = self._tags[0]
 			if self._verbose:
 				branch = self._include_branch_list[0]
 				print("{} branch found, no releases".format(branch), self._tags[0])
@@ -924,15 +926,15 @@ class SingletonUpdater:
 		for name in zfile.namelist():
 			if zsep not in name:
 				continue
-			top_folder = name[:name.index(zsep)+1]
+			top_folder = name[:name.index(zsep) + 1]
 			if name == top_folder + zsep:
 				continue  # skip top level folder
-			subpath = name[name.index(zsep)+1:]
+			sub_path = name[name.index(zsep)+1:]
 			if name.endswith(zsep):
 				try:
-					os.mkdir(os.path.join(outdir, subpath))
+					os.mkdir(os.path.join(outdir, sub_path))
 					if self._verbose:
-						print("Extract - mkdir: ", os.path.join(outdir, subpath))
+						print("Extract - mkdir: ", os.path.join(outdir, sub_path))
 				except OSError as exc:
 					if exc.errno != errno.EEXIST:
 						self._error = "Install failed"
@@ -940,11 +942,11 @@ class SingletonUpdater:
 						self.print_trace()
 						return -1
 			else:
-				with open(os.path.join(outdir, subpath), "wb") as outfile:
+				with open(os.path.join(outdir, sub_path), "wb") as outfile:
 					data = zfile.read(name)
 					outfile.write(data)
 					if self._verbose:
-						print("Extract - create:", os.path.join(outdir, subpath))
+						print("Extract - create:", os.path.join(outdir, sub_path))
 
 		if self._verbose:
 			print("Extracted source")
@@ -982,7 +984,7 @@ class SingletonUpdater:
 
 		# merge code with running addon directory, using blender default behavior
 		# plus any modifiers indicated by user (e.g. force remove/keep)
-		self.deepMergeDirectory(self._addon_root, unpath, clean)
+		self.deep_merge_directory(self._addon_root, unpath, clean)
 
 		# Now save the json state
 		#  Change to True, to trigger the handler on other side
@@ -993,7 +995,7 @@ class SingletonUpdater:
 		self._update_ready = False
 		return 0
 
-	def deepMergeDirectory(self, base, merger, clean=False):
+	def deep_merge_directory(self, base, merger, clean=False):
 		"""Merge folder 'merger' into folder 'base' without deleting existing"""
 		if not os.path.exists(base):
 			if self._verbose:
@@ -1094,7 +1096,7 @@ class SingletonUpdater:
 					# file did not previously exist, simply move it over
 					os.rename(srcFile, dest_file)
 					if self._verbose:
-						print("New file "+os.path.basename(dest_file))
+						print("New file " + os.path.basename(dest_file))
 
 		# now remove the temp staging folder and downloaded zip
 		try:

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -822,7 +822,7 @@ class SingletonUpdater:
 				shutil.rmtree(local)
 			except:
 				if self._verbose:
-					print("Failed to removed previous backup folder, contininuing")
+					print("Failed to removed previous backup folder, continuing")
 				self.print_trace()
 
 		# remove the temp folder; shouldn't exist but could if previously interrupted
@@ -831,7 +831,7 @@ class SingletonUpdater:
 				shutil.rmtree(tempdest)
 			except:
 				if self._verbose:
-					print("Failed to remove existing temp folder, contininuing")
+					print("Failed to remove existing temp folder, continuing")
 				self.print_trace()
 
 		# make the full addon copy, which temporarily places outside the addon folder

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -264,11 +264,11 @@ class SingletonUpdater:
 
 	# not currently used
 	@property
-	def include_branch_autocheck(self):
+	def include_branch_auto_check(self):
 		return self._include_branch_auto_check
 
-	@include_branch_autocheck.setter
-	def include_branch_autocheck(self, value):
+	@include_branch_auto_check.setter
+	def include_branch_auto_check(self, value):
 		try:
 			self._include_branch_auto_check = bool(value)
 		except:

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -52,7 +52,7 @@ DEFAULT_PER_PAGE = 30  # currently not used
 # -----------------------------------------------------------------------------
 # The main class
 # -----------------------------------------------------------------------------
-class Singleton_updater(object):
+class SingletonUpdater:
 	"""
 	This is the singleton class to reference a copy from,
 	it is the shared module level class
@@ -1637,7 +1637,7 @@ class Singleton_updater(object):
 # -----------------------------------------------------------------------------
 
 
-class BitbucketEngine(object):
+class BitbucketEngine:
 	"""Integration to Bitbucket API for git-formatted repositories"""
 
 	def __init__(self):
@@ -1666,7 +1666,7 @@ class BitbucketEngine(object):
 		return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["name"], updater)} for tag in response["values"]]
 
 
-class GithubEngine(object):
+class GithubEngine:
 	"""Integration to Github API"""
 
 	def __init__(self):
@@ -1697,7 +1697,7 @@ class GithubEngine(object):
 		return response
 
 
-class GitlabEngine(object):
+class GitlabEngine:
 	"""Integration to GitLab API"""
 
 	def __init__(self):
@@ -1744,4 +1744,4 @@ class GitlabEngine(object):
 # should be what's imported to other files
 # -----------------------------------------------------------------------------
 
-Updater = Singleton_updater()
+Updater = SingletonUpdater()

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -195,7 +195,7 @@ class SingletonUpdater:
 		if value is None:
 			self._backup_ignore_patterns = None
 			return
-		elif type(value) is not type(['list']):
+		elif not isinstance(value, list):
 			raise ValueError("Backup pattern must be in list format")
 		else:
 			self._backup_ignore_patterns = value
@@ -258,7 +258,7 @@ class SingletonUpdater:
 
 	@fake_install.setter
 	def fake_install(self, value):
-		if type(value) is not type(False):
+		if not isinstance(value, bool):
 			raise ValueError("fake_install must be a boolean value")
 		self._fake_install = bool(value)
 
@@ -283,7 +283,7 @@ class SingletonUpdater:
 		try:
 			if value is None:
 				self._include_branch_list = ['master']
-			elif type(value) is not type(['master']) or value is []:
+			elif not isinstance(value, list) or len(value) == 0:
 				raise ValueError("include_branch_list should be a list of valid branches")
 			else:
 				self._include_branch_list = value
@@ -303,7 +303,7 @@ class SingletonUpdater:
 
 	@property
 	def json(self):
-		if self._json == {}:
+		if len(self._json) == 0:
 			self.set_updater_json()
 		return self._json
 
@@ -332,7 +332,7 @@ class SingletonUpdater:
 	def overwrite_patterns(self, value):
 		if value is None:
 			self._overwrite_patterns = ["*.py", "*.pyc"]
-		elif type(value) is not type(['']):
+		elif not isinstance(value, list):
 			raise ValueError("overwrite_patterns needs to be in a list format")
 		else:
 			self._overwrite_patterns = value
@@ -355,8 +355,8 @@ class SingletonUpdater:
 	@remove_pre_update_patterns.setter
 	def remove_pre_update_patterns(self, value):
 		if value is None:
-			self._remove_pre_update_patterns = []
-		elif type(value) is not type(['']):
+			self._remove_pre_update_patterns = list()
+		elif not isinstance(value, list):
 			raise ValueError("remove_pre_update_patterns needs to be in a list format")
 		else:
 			self._remove_pre_update_patterns = value
@@ -414,9 +414,9 @@ class SingletonUpdater:
 
 	@property
 	def tags(self):
-		if self._tags is []:
+		if len(self._tags) == 0:
 			return []
-		tag_names = []
+		tag_names = list()
 		for tag in self._tags:
 			tag_names.append(tag["name"])
 		return tag_names
@@ -470,7 +470,7 @@ class SingletonUpdater:
 		try:
 			self._verbose = bool(value)
 			if self._verbose:
-				print(self._addon+" updater verbose is enabled")
+				print(self._addon + " updater verbose is enabled")
 		except:
 			raise ValueError("Verbose must be a boolean value")
 
@@ -494,7 +494,7 @@ class SingletonUpdater:
 		if value is None:
 			self._version_max_update = None
 			return
-		if type(value) is not type((1, 2, 3)):
+		if not isinstance(value, tuple):
 			raise ValueError("Version maximum must be a tuple")
 		for subvalue in value:
 			if type(subvalue) is not int:
@@ -510,7 +510,7 @@ class SingletonUpdater:
 		if value is None:
 			self._version_min_update = None
 			return
-		if type(value) is not type((1, 2, 3)):
+		if not isinstance(value, tuple):
 			raise ValueError("Version minimum must be a tuple")
 		for subvalue in value:
 			if type(subvalue) != int:
@@ -642,7 +642,7 @@ class SingletonUpdater:
 			if self._verbose:
 				branch = self._include_branch_list[0]
 				print("{} branch found, no releases".format(branch), self._tags[0])
-		elif (len(self._tags)-len(self._include_branch_list) == 0 and self._include_branches) \
+		elif (len(self._tags) - len(self._include_branch_list) == 0 and self._include_branches) \
 				or (len(self._tags) == 0 and not self._include_branches) \
 				and self._prefiltered_tag_count > 0:
 			self._tag_latest = None
@@ -793,7 +793,7 @@ class SingletonUpdater:
 			# Always set user agent
 			request.add_header('User-Agent', "Python/" + str(platform.python_version()))
 
-			self.urlretrieve(urllib.request.urlopen(request, context=context), self._source_zip)
+			self.url_retrieve(urllib.request.urlopen(request, context=context), self._source_zip)
 			# add additional checks on file size being non-zero
 			if self._verbose:
 				print("Successfully downloaded update zip")
@@ -857,7 +857,7 @@ class SingletonUpdater:
 			print("Backing up current addon folder")
 		backuploc = os.path.join(self._updater_path, "backup")
 		tempdest = os.path.join(self._addon_root, os.pardir,
-						self._addon+"_updater_backup_temp")
+						self._addon + "_updater_backup_temp")
 		tempdest = os.path.abspath(tempdest)
 
 		# make the copy
@@ -1144,8 +1144,8 @@ class SingletonUpdater:
 		self._error_msg = None
 
 	# custom urlretrieve implementation
-	def urlretrieve(self, url_file, filepath):
-		chunk = 1024*8
+	def url_retrieve(self, url_file, filepath):
+		chunk = 1024 * 8
 		f = open(filepath, "wb")
 		while 1:
 			data = url_file.read(chunk)
@@ -1153,7 +1153,7 @@ class SingletonUpdater:
 				# print("done.")
 				break
 			f.write(data)
-			# print("Read %s bytes"%len(data))
+			# print("Read %s bytes" % len(data))
 		f.close()
 
 	def version_tuple_from_text(self, text):
@@ -1533,7 +1533,7 @@ class SingletonUpdater:
 	def save_updater_json(self):
 		# first save the state
 		if self._update_ready:
-			if type(self._update_version) == type((0, 0, 0)):
+			if isinstance(self._update_version, tuple):
 				self._json["update_ready"] = True
 				self._json["version_text"]["link"] = self._update_link
 				self._json["version_text"]["version"] = self._update_version

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -23,7 +23,7 @@ https://github.com/CGCookie/blender-addon-updater
 
 """
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 
 import errno
 import traceback
@@ -46,16 +46,13 @@ import addon_utils
 # -----------------------------------------------------------------------------
 # Define error messages/notices & hard coded globals
 # -----------------------------------------------------------------------------
-
-# currently not used
-DEFAULT_TIMEOUT = 10
-DEFAULT_PER_PAGE = 30
+DEFAULT_TIMEOUT = 10  # currently not used
+DEFAULT_PER_PAGE = 30  # currently not used
 
 
 # -----------------------------------------------------------------------------
 # The main class
 # -----------------------------------------------------------------------------
-
 class Singleton_updater(object):
 	"""
 	This is the singleton class to reference a copy from,
@@ -117,7 +114,7 @@ class Singleton_updater(object):
 		self._addon = __package__.lower()
 		self._addon_package = __package__  # must not change
 		self._updater_path = os.path.join(os.path.dirname(__file__),
-										self._addon+"_updater")
+										self._addon + "_updater")
 		self._addon_root = os.path.dirname(__file__)
 		self._json = {}
 		self._error = None
@@ -137,21 +134,18 @@ class Singleton_updater(object):
 
 		self._select_link = select_link_function
 
-
 	def print_trace(self):
 		"""Print handled exception details when use_print_traces is set"""
 		if self._use_print_traces:
 			traceback.print_exc()
 
-
 	# -------------------------------------------------------------------------
 	# Getters and setters
 	# -------------------------------------------------------------------------
-
-
 	@property
 	def addon(self):
 		return self._addon
+
 	@addon.setter
 	def addon(self, value):
 		self._addon = str(value)
@@ -159,9 +153,10 @@ class Singleton_updater(object):
 	@property
 	def api_url(self):
 		return self._engine.api_url
+
 	@api_url.setter
 	def api_url(self, value):
-		if self.check_is_url(value) == False:
+		if not self.check_is_url(value):
 			raise ValueError("Not a valid URL: " + value)
 		self._engine.api_url = value
 
@@ -172,6 +167,7 @@ class Singleton_updater(object):
 	@property
 	def auto_reload_post_update(self):
 		return self._auto_reload_post_update
+
 	@auto_reload_post_update.setter
 	def auto_reload_post_update(self, value):
 		try:
@@ -182,9 +178,10 @@ class Singleton_updater(object):
 	@property
 	def backup_current(self):
 		return self._backup_current
+
 	@backup_current.setter
 	def backup_current(self, value):
-		if value == None:
+		if value is None:
 			self._backup_current = False
 			return
 		else:
@@ -193,12 +190,13 @@ class Singleton_updater(object):
 	@property
 	def backup_ignore_patterns(self):
 		return self._backup_ignore_patterns
+
 	@backup_ignore_patterns.setter
 	def backup_ignore_patterns(self, value):
-		if value == None:
+		if value is None:
 			self._backup_ignore_patterns = None
 			return
-		elif type(value) != type(['list']):
+		elif type(value) is not type(['list']):
 			raise ValueError("Backup pattern must be in list format")
 		else:
 			self._backup_ignore_patterns = value
@@ -214,9 +212,10 @@ class Singleton_updater(object):
 	@property
 	def current_version(self):
 		return self._current_version
+
 	@current_version.setter
 	def current_version(self, tuple_values):
-		if tuple_values==None:
+		if tuple_values is None:
 			self._current_version = None
 			return
 		elif type(tuple_values) is not tuple:
@@ -224,23 +223,24 @@ class Singleton_updater(object):
 				tuple(tuple_values)
 			except:
 				raise ValueError(
-				"Not a tuple! current_version must be a tuple of integers")
+					"Not a tuple! current_version must be a tuple of integers")
 		for i in tuple_values:
 			if type(i) is not int:
 				raise ValueError(
-				"Not an integer! current_version must be a tuple of integers")
+					"Not an integer! current_version must be a tuple of integers")
 		self._current_version = tuple(tuple_values)
 
 	@property
 	def engine(self):
 		return self._engine.name
+
 	@engine.setter
 	def engine(self, value):
-		if value.lower()=="github":
+		if value.lower() is "github":
 			self._engine = GithubEngine()
-		elif value.lower()=="gitlab":
+		elif value.lower() is "gitlab":
 			self._engine = GitlabEngine()
-		elif value.lower()=="bitbucket":
+		elif value.lower() is "bitbucket":
 			self._engine = BitbucketEngine()
 		else:
 			raise ValueError("Invalid engine selection")
@@ -256,9 +256,10 @@ class Singleton_updater(object):
 	@property
 	def fake_install(self):
 		return self._fake_install
+
 	@fake_install.setter
 	def fake_install(self, value):
-		if type(value) != type(False):
+		if type(value) is not type(False):
 			raise ValueError("fake_install must be a boolean value")
 		self._fake_install = bool(value)
 
@@ -266,6 +267,7 @@ class Singleton_updater(object):
 	@property
 	def include_branch_autocheck(self):
 		return self._include_branch_autocheck
+
 	@include_branch_autocheck.setter
 	def include_branch_autocheck(self, value):
 		try:
@@ -276,12 +278,13 @@ class Singleton_updater(object):
 	@property
 	def include_branch_list(self):
 		return self._include_branch_list
+
 	@include_branch_list.setter
 	def include_branch_list(self, value):
 		try:
-			if value == None:
+			if value is None:
 				self._include_branch_list = ['master']
-			elif type(value) != type(['master']) or value==[]:
+			elif type(value) is not type(['master']) or value is []:
 				raise ValueError("include_branch_list should be a list of valid branches")
 			else:
 				self._include_branch_list = value
@@ -291,6 +294,7 @@ class Singleton_updater(object):
 	@property
 	def include_branches(self):
 		return self._include_branches
+
 	@include_branches.setter
 	def include_branches(self, value):
 		try:
@@ -306,13 +310,14 @@ class Singleton_updater(object):
 
 	@property
 	def latest_release(self):
-		if self._latest_release == None:
+		if self._latest_release is None:
 			return None
 		return self._latest_release
 
 	@property
 	def manual_only(self):
 		return self._manual_only
+
 	@manual_only.setter
 	def manual_only(self, value):
 		try:
@@ -323,11 +328,12 @@ class Singleton_updater(object):
 	@property
 	def overwrite_patterns(self):
 		return self._overwrite_patterns
+
 	@overwrite_patterns.setter
 	def overwrite_patterns(self, value):
-		if value == None:
-			self._overwrite_patterns = ["*.py","*.pyc"]
-		elif type(value) != type(['']):
+		if value is None:
+			self._overwrite_patterns = ["*.py", "*.pyc"]
+		elif type(value) is not type(['']):
 			raise ValueError("overwrite_patterns needs to be in a list format")
 		else:
 			self._overwrite_patterns = value
@@ -335,9 +341,10 @@ class Singleton_updater(object):
 	@property
 	def private_token(self):
 		return self._engine.token
+
 	@private_token.setter
 	def private_token(self, value):
-		if value==None:
+		if value is None:
 			self._engine.token = None
 		else:
 			self._engine.token = str(value)
@@ -345,11 +352,12 @@ class Singleton_updater(object):
 	@property
 	def remove_pre_update_patterns(self):
 		return self._remove_pre_update_patterns
+
 	@remove_pre_update_patterns.setter
 	def remove_pre_update_patterns(self, value):
-		if value == None:
+		if value is None:
 			self._remove_pre_update_patterns = []
-		elif type(value) != type(['']):
+		elif type(value) is not type(['']):
 			raise ValueError("remove_pre_update_patterns needs to be in a list format")
 		else:
 			self._remove_pre_update_patterns = value
@@ -357,6 +365,7 @@ class Singleton_updater(object):
 	@property
 	def repo(self):
 		return self._repo
+
 	@repo.setter
 	def repo(self, value):
 		try:
@@ -367,6 +376,7 @@ class Singleton_updater(object):
 	@property
 	def select_link(self):
 		return self._select_link
+
 	@select_link.setter
 	def select_link(self, value):
 		# ensure it is a function assignment, with signature:
@@ -378,16 +388,19 @@ class Singleton_updater(object):
 	@property
 	def stage_path(self):
 		return self._updater_path
+
 	@stage_path.setter
 	def stage_path(self, value):
-		if value == None:
-			if self._verbose: print("Aborting assigning stage_path, it's null")
+		if value is None:
+			if self._verbose:
+				print("Aborting assigning stage_path, it's null")
 			return
-		elif value != None and not os.path.exists(value):
+		elif value is not None and not os.path.exists(value):
 			try:
 				os.makedirs(value)
 			except:
-				if self._verbose: print("Error trying to staging path")
+				if self._verbose:
+					print("Error trying to staging path")
 				self.print_trace()
 				return
 		self._updater_path = value
@@ -395,13 +408,14 @@ class Singleton_updater(object):
 	@property
 	def subfolder_path(self):
 		return self._subfolder_path
+
 	@subfolder_path.setter
 	def subfolder_path(self, value):
 		self._subfolder_path = value
 
 	@property
 	def tags(self):
-		if self._tags == []:
+		if self._tags is []:
 			return []
 		tag_names = []
 		for tag in self._tags:
@@ -410,7 +424,7 @@ class Singleton_updater(object):
 
 	@property
 	def tag_latest(self):
-		if self._tag_latest == None:
+		if self._tag_latest is None:
 			return None
 		return self._tag_latest["name"]
 
@@ -429,6 +443,7 @@ class Singleton_updater(object):
 	@property
 	def use_releases(self):
 		return self._use_releases
+
 	@use_releases.setter
 	def use_releases(self, value):
 		try:
@@ -439,6 +454,7 @@ class Singleton_updater(object):
 	@property
 	def user(self):
 		return self._user
+
 	@user.setter
 	def user(self, value):
 		try:
@@ -449,11 +465,12 @@ class Singleton_updater(object):
 	@property
 	def verbose(self):
 		return self._verbose
+
 	@verbose.setter
 	def verbose(self, value):
 		try:
 			self._verbose = bool(value)
-			if self._verbose == True:
+			if self._verbose:
 				print(self._addon+" updater verbose is enabled")
 		except:
 			raise ValueError("Verbose must be a boolean value")
@@ -461,6 +478,7 @@ class Singleton_updater(object):
 	@property
 	def use_print_traces(self):
 		return self._use_print_traces
+
 	@use_print_traces.setter
 	def use_print_traces(self, value):
 		try:
@@ -471,27 +489,29 @@ class Singleton_updater(object):
 	@property
 	def version_max_update(self):
 		return self._version_max_update
+
 	@version_max_update.setter
 	def version_max_update(self, value):
-		if value == None:
+		if value is None:
 			self._version_max_update = None
 			return
-		if type(value) != type((1,2,3)):
+		if type(value) is not type((1, 2, 3)):
 			raise ValueError("Version maximum must be a tuple")
 		for subvalue in value:
-			if type(subvalue) != int:
+			if type(subvalue) is not int:
 				raise ValueError("Version elements must be integers")
 		self._version_max_update = value
 
 	@property
 	def version_min_update(self):
 		return self._version_min_update
+
 	@version_min_update.setter
 	def version_min_update(self, value):
-		if value == None:
+		if value is None:
 			self._version_min_update = None
 			return
-		if type(value) != type((1,2,3)):
+		if type(value) is not type((1, 2, 3)):
 			raise ValueError("Version minimum must be a tuple")
 		for subvalue in value:
 			if type(subvalue) != int:
@@ -501,37 +521,36 @@ class Singleton_updater(object):
 	@property
 	def website(self):
 		return self._website
+
 	@website.setter
 	def website(self, value):
-		if self.check_is_url(value) == False:
+		if not self.check_is_url(value):
 			raise ValueError("Not a valid URL: " + value)
 		self._website = value
-
 
 	# -------------------------------------------------------------------------
 	# Parameter validation related functions
 	# -------------------------------------------------------------------------
-
-
-	def check_is_url(self, url):
+	@staticmethod
+	def check_is_url(url):
 		if not ("http://" in url or "https://" in url):
 			return False
 		if "." not in url:
 			return False
 		return True
 
-	def get_tag_names(self):
+	def _get_tag_names(self):
 		tag_names = []
 		self.get_tags()
 		for tag in self._tags:
 			tag_names.append(tag["name"])
 		return tag_names
 
-	def set_check_interval(self,enable=False,months=0,days=14,hours=0,minutes=0):
+	def set_check_interval(self, enabled=False, months=0, days=14, hours=0, minutes=0):
 		# enabled = False, default initially will not check against frequency
 		# if enabled, default is then 2 weeks
 
-		if type(enable) is not bool:
+		if type(enabled) is not bool:
 			raise ValueError("Enable must be a boolean value")
 		if type(months) is not int:
 			raise ValueError("Months must be an integer value")
@@ -542,7 +561,7 @@ class Singleton_updater(object):
 		if type(minutes) is not int:
 			raise ValueError("Minutes must be an integer value")
 
-		if enable==False:
+		if not enabled:
 			self._check_interval_enable = False
 		else:
 			self._check_interval_enable = True
@@ -562,11 +581,9 @@ class Singleton_updater(object):
 						a=self._user,
 						b=self._repo, c=self.form_repo_url())
 
-
 	# -------------------------------------------------------------------------
 	# API-related functions
 	# -------------------------------------------------------------------------
-
 	def form_repo_url(self):
 		return self._engine.form_repo_url(self)
 
@@ -589,57 +606,60 @@ class Singleton_updater(object):
 			all_tags = []
 
 		# pre-process to skip tags
-		if self.skip_tag != None:
+		if self.skip_tag is not None:
 			self._tags = [tg for tg in all_tags if self.skip_tag(self, tg)==False]
 		else:
 			self._tags = all_tags
 
 		# get additional branches too, if needed, and place in front
 		# Does NO checking here whether branch is valid
-		if self._include_branches == True:
+		if self._include_branches:
 			temp_branches = self._include_branch_list.copy()
 			temp_branches.reverse()
 			for branch in temp_branches:
 				request = self.form_branch_url(branch)
 				include = {
-					"name":branch.title(),
-					"zipball_url":request
+					"name": branch.title(),
+					"zipball_url": request
 				}
 				self._tags = [include] + self._tags  # append to front
 
-		if self._tags == None:
+		if self._tags is None:
 			# some error occurred
 			self._tag_latest = None
 			self._tags = []
 			return
-		elif self._prefiltered_tag_count == 0 and self._include_branches == False:
+		elif self._prefiltered_tag_count == 0 and not self._include_branches:
 			self._tag_latest = None
-			if self._error == None: # if not None, could have had no internet
+			if self._error is None: # if not None, could have had no internet
 				self._error = "No releases found"
 				self._error_msg = "No releases or tags found on this repository"
-			if self._verbose: print("No releases or tags found on this repository")
-		elif self._prefiltered_tag_count == 0 and self._include_branches == True:
+			if self._verbose:
+				print("No releases or tags found on this repository")
+		elif self._prefiltered_tag_count == 0 and self._include_branches:
 			if not self._error: self._tag_latest = self._tags[0]
 			if self._verbose:
 				branch = self._include_branch_list[0]
 				print("{} branch found, no releases".format(branch), self._tags[0])
-		elif (len(self._tags)-len(self._include_branch_list)==0 and self._include_branches==True) \
-				or (len(self._tags)==0 and self._include_branches==False) \
+		elif (len(self._tags)-len(self._include_branch_list) == 0 and self._include_branches) \
+				or (len(self._tags) == 0 and not self._include_branches) \
 				and self._prefiltered_tag_count > 0:
 			self._tag_latest = None
 			self._error = "No releases available"
 			self._error_msg = "No versions found within compatible version range"
-			if self._verbose: print("No versions found within compatible version range")
+			if self._verbose:
+				print("No versions found within compatible version range")
 		else:
-			if self._include_branches == False:
+			if not self._include_branches:
 				self._tag_latest = self._tags[0]
-				if self._verbose: print("Most recent tag found:",self._tags[0]['name'])
+				if self._verbose:
+					print("Most recent tag found:",self._tags[0]['name'])
 			else:
 				# don't return branch if in list
 				n = len(self._include_branch_list)
 				self._tag_latest = self._tags[n]  # guaranteed at least len()=n+1
-				if self._verbose: print("Most recent tag found:",self._tags[n]['name'])
-
+				if self._verbose:
+					print("Most recent tag found:", self._tags[n]['name'])
 
 	# all API calls to base url
 	def get_raw(self, url):
@@ -653,14 +673,15 @@ class Singleton_updater(object):
 			context = None
 
 		# setup private request headers if appropriate
-		if self._engine.token != None:
+		if self._engine.token is not None:
 			if self._engine.name == "gitlab":
-				request.add_header('PRIVATE-TOKEN',self._engine.token)
+				request.add_header('PRIVATE-TOKEN', self._engine.token)
 			else:
-				if self._verbose: print("Tokens not setup for engine yet")
+				if self._verbose:
+					print("Tokens not setup for engine yet")
 
 		# Always set user agent
-		request.add_header('User-Agent', "Python/"+str(platform.python_version()))
+		request.add_header('User-Agent', "Python/" + str(platform.python_version()))
 
 		# run the request
 		try:
@@ -697,13 +718,12 @@ class Singleton_updater(object):
 			result.close()
 			return result_string.decode()
 
-
 	# result of all api calls, decoded into json format
 	def get_api(self, url):
 		# return the json version
 		get = None
 		get = self.get_raw(url)
-		if get != None:
+		if get is not None:
 			try:
 				return json.JSONDecoder().decode(get)
 			except Exception as e:
@@ -716,7 +736,6 @@ class Singleton_updater(object):
 		else:
 			return None
 
-
 	# create a working directory and download the new files
 	def stage_repository(self, url):
 
@@ -726,7 +745,7 @@ class Singleton_updater(object):
 		# make/clear the staging folder
 		# ensure the folder is always "clean"
 		if self._verbose: print("Preparing staging folder for download:\n",local)
-		if os.path.isdir(local) == True:
+		if os.path.isdir(local):
 			try:
 				shutil.rmtree(local)
 				os.makedirs(local)
@@ -740,32 +759,36 @@ class Singleton_updater(object):
 				error = "failed to create staging directory"
 				self.print_trace()
 
-		if error != None:
+		if error is not None:
 			if self._verbose: print("Error: Aborting update, "+error)
 			self._error = "Update aborted, staging path error"
 			self._error_msg = "Error: {}".format(error)
 			return False
 
-		if self._backup_current==True:
+		if self._backup_current:
 			self.create_backup()
-		if self._verbose: print("Now retrieving the new source zip")
 
-		self._source_zip = os.path.join(local,"source.zip")
+		if self._verbose:
+			print("Now retrieving the new source zip")
 
-		if self._verbose: print("Starting download update zip")
+		self._source_zip = os.path.join(local, "source.zip")
+
+		if self._verbose:
+			print("Starting download update zip")
 		try:
 			request = urllib.request.Request(url)
 			context = ssl._create_unverified_context()
 
 			# setup private token if appropriate
-			if self._engine.token != None:
+			if self._engine.token is not None:
 				if self._engine.name == "gitlab":
-					request.add_header('PRIVATE-TOKEN',self._engine.token)
+					request.add_header('PRIVATE-TOKEN', self._engine.token)
 				else:
-					if self._verbose: print("Tokens not setup for selected engine yet")
+					if self._verbose:
+						print("Tokens not setup for selected engine yet")
 
 			# Always set user agent
-			request.add_header('User-Agent', "Python/"+str(platform.python_version()))
+			request.add_header('User-Agent', "Python/" + str(platform.python_version()))
 
 			self.urlretrieve(urllib.request.urlopen(request,context=context), self._source_zip)
 			# add additional checks on file size being non-zero
@@ -780,21 +803,22 @@ class Singleton_updater(object):
 			self.print_trace()
 			return False
 
-
 	def create_backup(self):
-		if self._verbose: print("Backing up current addon folder")
+		if self._verbose:
+			print("Backing up current addon folder")
 		local = os.path.join(self._updater_path,"backup")
-		tempdest = os.path.join(self._addon_root,
-						os.pardir,
-						self._addon+"_updater_backup_temp")
+		tempdest = os.path.join(self._addon_root, os.pardir,
+								self._addon + "_updater_backup_temp")
 
-		if self._verbose: print("Backup destination path: ",local)
+		if self._verbose:
+			print("Backup destination path: ",local)
 
 		if os.path.isdir(local):
 			try:
 				shutil.rmtree(local)
 			except:
-				if self._verbose:print("Failed to removed previous backup folder, contininuing")
+				if self._verbose:
+					print("Failed to removed previous backup folder, contininuing")
 				self.print_trace()
 
 		# remove the temp folder; shouldn't exist but could if previously interrupted
@@ -802,37 +826,39 @@ class Singleton_updater(object):
 			try:
 				shutil.rmtree(tempdest)
 			except:
-				if self._verbose:print("Failed to remove existing temp folder, contininuing")
+				if self._verbose:
+					print("Failed to remove existing temp folder, contininuing")
 				self.print_trace()
+
 		# make the full addon copy, which temporarily places outside the addon folder
-		if self._backup_ignore_patterns != None:
+		if self._backup_ignore_patterns is not None:
 			shutil.copytree(
-				self._addon_root,tempdest,
+				self._addon_root, tempdest,
 				ignore=shutil.ignore_patterns(*self._backup_ignore_patterns))
 		else:
 			shutil.copytree(self._addon_root,tempdest)
-		shutil.move(tempdest,local)
+		shutil.move(tempdest, local)
 
 		# save the date for future ref
 		now = datetime.now()
 		self._json["backup_date"] = "{m}-{d}-{yr}".format(
-				m=now.strftime("%B"),d=now.day,yr=now.year)
+				m=now.strftime("%B"), d=now.day,yr=now.year)
 		self.save_updater_json()
 
 	def restore_backup(self):
-		if self._verbose: print("Restoring backup")
+		if self._verbose:
+			print("Restoring backup")
 
 		if self._verbose: print("Backing up current addon folder")
-		backuploc = os.path.join(self._updater_path,"backup")
-		tempdest = os.path.join(self._addon_root,
-						os.pardir,
+		backuploc = os.path.join(self._updater_path, "backup")
+		tempdest = os.path.join(self._addon_root, os.pardir,
 						self._addon+"_updater_backup_temp")
 		tempdest = os.path.abspath(tempdest)
 
 		# make the copy
-		shutil.move(backuploc,tempdest)
+		shutil.move(backuploc, tempdest)
 		shutil.rmtree(self._addon_root)
-		os.rename(tempdest,self._addon_root)
+		os.rename(tempdest, self._addon_root)
 
 		self._json["backup_date"] = ""
 		self._json["just_restored"] = True
@@ -843,7 +869,7 @@ class Singleton_updater(object):
 
 	def unpack_staged_zip(self,clean=False):
 		"""Unzip the downloaded file, and validate contents"""
-		if os.path.isfile(self._source_zip) == False:
+		if not os.path.isfile(self._source_zip):
 			if self._verbose: print("Error, update zip not found")
 			self._error = "Install failed"
 			self._error_msg = "Downloaded zip not found"
@@ -890,7 +916,7 @@ class Singleton_updater(object):
 		# Now extract directly from the first subfolder (not root)
 		# this avoids adding the first subfolder to the path length,
 		# which can be too long if the download has the SHA in the name
-		zsep = '/'  #os.sep  # might just always be / even on windows
+		zsep = '/'  # os.sep  # might just always be / even on windows
 		for name in zfile.namelist():
 			if zsep not in name:
 				continue
@@ -931,17 +957,17 @@ class Singleton_updater(object):
 			self._subfolder_path.replace('\\', os.path.sep)
 
 		# either directly in root of zip/one subfolder, or use specified path
-		if os.path.isfile(os.path.join(unpath,"__init__.py")) == False:
+		if not os.path.isfile(os.path.join(unpath, "__init__.py")):
 			dirlist = os.listdir(unpath)
-			if len(dirlist)>0:
-				if self._subfolder_path == "" or self._subfolder_path == None:
+			if len(dirlist) > 0:
+				if self._subfolder_path == "" or self._subfolder_path is None:
 					unpath = os.path.join(unpath, dirlist[0])
 				else:
 					unpath = os.path.join(unpath, self._subfolder_path)
 
 			# smarter check for additional sub folders for a single folder
 			# containing __init__.py
-			if os.path.isfile(os.path.join(unpath,"__init__.py")) == False:
+			if not os.path.isfile(os.path.join(unpath,"__init__.py")):
 				if self._verbose:
 					print("not a valid addon found")
 					print("Paths:")
@@ -963,8 +989,7 @@ class Singleton_updater(object):
 		self._update_ready = False
 		return 0
 
-
-	def deepMergeDirectory(self,base,merger,clean=False):
+	def deepMergeDirectory(self, base, merger, clean=False):
 		"""Merge folder 'merger' into folder 'base' without deleting existing"""
 		if not os.path.exists(base):
 			if self._verbose:
@@ -976,33 +1001,35 @@ class Singleton_updater(object):
 			return -1
 
 		# paths to be aware of and not overwrite/remove/etc
-		staging_path = os.path.join(self._updater_path,"update_staging")
-		backup_path = os.path.join(self._updater_path,"backup")
+		staging_path = os.path.join(self._updater_path, "update_staging")
+		backup_path = os.path.join(self._updater_path, "backup")
 
 		# If clean install is enabled, clear existing files ahead of time
 		# note: will not delete the update.json, update folder, staging, or staging
 		# but will delete all other folders/files in addon directory
 		error = None
-		if clean==True:
+		if clean:
 			try:
 				# implement clearing of all folders/files, except the
 				# updater folder and updater json
 				# Careful, this deletes entire subdirectories recursively...
 				# make sure that base is not a high level shared folder, but
 				# is dedicated just to the addon itself
-				if self._verbose: print("clean=True, clearing addon folder to fresh install state")
+				if self._verbose:
+					print("clean=True, clearing addon folder to fresh install state")
 
 				# remove root files and folders (except update folder)
-				files = [f for f in os.listdir(base) if os.path.isfile(os.path.join(base,f))]
-				folders = [f for f in os.listdir(base) if os.path.isdir(os.path.join(base,f))]
+				files = [f for f in os.listdir(base) if os.path.isfile(os.path.join(base, f))]
+				folders = [f for f in os.listdir(base) if os.path.isdir(os.path.join(base, f))]
 
 				for f in files:
-					os.remove(os.path.join(base,f))
-					print("Clean removing file {}".format(os.path.join(base,f)))
+					os.remove(os.path.join(base, f))
+					print("Clean removing file {}".format(os.path.join(base, f)))
 				for f in folders:
-					if os.path.join(base,f)==self._updater_path: continue
-					shutil.rmtree(os.path.join(base,f))
-					print("Clean removing folder and contents {}".format(os.path.join(base,f)))
+					if os.path.join(base, f) is self._updater_path:
+						continue
+					shutil.rmtree(os.path.join(base, f))
+					print("Clean removing folder and contents {}".format(os.path.join(base, f)))
 
 			except Exception as err:
 				error = "failed to create clean existing addon folder"
@@ -1013,16 +1040,17 @@ class Singleton_updater(object):
 		# but avoid removing/altering backup and updater file
 		for path, dirs, files in os.walk(base):
 			# prune ie skip updater folder
-			dirs[:] = [d for d in dirs if os.path.join(path,d) not in [self._updater_path]]
+			dirs[:] = [d for d in dirs if os.path.join(path, d) not in [self._updater_path]]
 			for file in files:
 				for ptrn in self.remove_pre_update_patterns:
-					if fnmatch.filter([file],ptrn):
+					if fnmatch.filter([file], ptrn):
 						try:
-							fl = os.path.join(path,file)
+							fl = os.path.join(path, file)
 							os.remove(fl)
-							if self._verbose: print("Pre-removed file "+file)
+							if self._verbose:
+								print("Pre-removed file " + file)
 						except OSError:
-							print("Failed to pre-remove "+file)
+							print("Failed to pre-remove " + file)
 							self.print_trace()
 
 		# Walk through the temp addon sub folder for replacements
@@ -1031,7 +1059,7 @@ class Singleton_updater(object):
 		# actual file copying/replacements
 		for path, dirs, files in os.walk(merger):
 			# verify this structure works to prune updater sub folder overwriting
-			dirs[:] = [d for d in dirs if os.path.join(path,d) not in [self._updater_path]]
+			dirs[:] = [d for d in dirs if os.path.join(path, d) not in [self._updater_path]]
 			relPath = os.path.relpath(path, merger)
 			destPath = os.path.join(base, relPath)
 			if not os.path.exists(destPath):
@@ -1045,60 +1073,62 @@ class Singleton_updater(object):
 				# decide whether to replace if file already exists, and copy new over
 				if os.path.isfile(destFile):
 					# otherwise, check each file to see if matches an overwrite pattern
-					replaced=False
+					replaced = False
 					for ptrn in self._overwrite_patterns:
-						if fnmatch.filter([file],ptrn):
-							replaced=True
+						if fnmatch.filter([file], ptrn):
+							replaced = True
 							break
 					if replaced:
 						os.remove(destFile)
 						os.rename(srcFile, destFile)
-						if self._verbose: print("Overwrote file "+os.path.basename(destFile))
+						if self._verbose:
+							print("Overwrote file " + os.path.basename(destFile))
 					else:
-						if self._verbose: print("Pattern not matched to "+os.path.basename(destFile)+", not overwritten")
+						if self._verbose:
+							print("Pattern not matched to " + os.path.basename(destFile) + ", not overwritten")
 				else:
 					# file did not previously exist, simply move it over
 					os.rename(srcFile, destFile)
-					if self._verbose: print("New file "+os.path.basename(destFile))
+					if self._verbose:
+						print("New file "+os.path.basename(destFile))
 
 		# now remove the temp staging folder and downloaded zip
 		try:
 			shutil.rmtree(staging_path)
 		except:
-			error = "Error: Failed to remove existing staging directory, consider manually removing "+staging_path
-			if self._verbose: print(error)
+			error = "Error: Failed to remove existing staging directory, consider manually removing " + staging_path
+			if self._verbose:
+				print(error)
 			self.print_trace()
-
 
 	def reload_addon(self):
 		# if post_update false, skip this function
 		# else, unload/reload addon & trigger popup
-		if self._auto_reload_post_update == False:
+		if not self._auto_reload_post_update:
 			print("Restart blender to reload addon and complete update")
 			return
 
-		if self._verbose: print("Reloading addon...")
+		if self._verbose:
+			print("Reloading addon...")
 		addon_utils.modules(refresh=True)
 		bpy.utils.refresh_script_paths()
 
 		# not allowed in restricted context, such as register module
 		# toggle to refresh
-		if "addon_disable" in dir(bpy.ops.wm): # 2.7
+		if "addon_disable" in dir(bpy.ops.wm):  # 2.7
 			bpy.ops.wm.addon_disable(module=self._addon_package)
 			bpy.ops.wm.addon_refresh()
 			bpy.ops.wm.addon_enable(module=self._addon_package)
 			print("2.7 reload complete")
-		else: # 2.8
+		else:  # 2.8
 			bpy.ops.preferences.addon_disable(module=self._addon_package)
 			bpy.ops.preferences.addon_refresh()
 			bpy.ops.preferences.addon_enable(module=self._addon_package)
 			print("2.8 reload complete")
 
-
 	# -------------------------------------------------------------------------
 	# Other non-api functions and setups
 	# -------------------------------------------------------------------------
-
 	def clear_state(self):
 		self._update_ready = None
 		self._update_link = None
@@ -1114,33 +1144,34 @@ class Singleton_updater(object):
 		while 1:
 			data = urlfile.read(chunk)
 			if not data:
-				#print("done.")
+				# print("done.")
 				break
 			f.write(data)
-			#print("Read %s bytes"%len(data))
+			# print("Read %s bytes"%len(data))
 		f.close()
 
-
-	def version_tuple_from_text(self,text):
-		if text == None: return ()
+	def version_tuple_from_text(self, text):
+		if text is None:
+			return ()
 
 		# should go through string and remove all non-integers,
 		# and for any given break split into a different section
 		segments = []
 		tmp = ''
-		for l in str(text):
-			if l.isdigit()==False:
-				if len(tmp)>0:
+		for char in str(text):
+			if not char.isdigit():
+				if len(tmp) > 0:
 					segments.append(int(tmp))
 					tmp = ''
 			else:
-				tmp+=l
-		if len(tmp)>0:
+				tmp += char
+		if len(tmp) > 0:
 			segments.append(int(tmp))
 
-		if len(segments)==0:
-			if self._verbose: print("No version strings found text: ",text)
-			if self._include_branches == False:
+		if len(segments) == 0:
+			if self._verbose:
+				print("No version strings found text: ",text)
+			if not self._include_branches:
 				return ()
 			else:
 				return (text)
@@ -1149,8 +1180,8 @@ class Singleton_updater(object):
 	# called for running check in a background thread
 	def check_for_update_async(self, callback=None):
 
-		if self._json != None and "update_ready" in self._json and self._json["version_text"]!={}:
-			if self._json["update_ready"] == True:
+		if self._json is not None and "update_ready" in self._json and self._json["version_text"] is not {}:
+			if self._json["update_ready"]:
 				self._update_ready = True
 				self._update_link = self._json["version_text"]["link"]
 				self._update_version = str(self._json["version_text"]["version"])
@@ -1159,14 +1190,13 @@ class Singleton_updater(object):
 				return
 
 		# do the check
-		if self._check_interval_enable == False:
+		if not self._check_interval_enable:
 			return
-		elif self._async_checking == True:
+		elif self._async_checking:
 			if self._verbose: print("Skipping async check, already started")
 			return  # already running the bg thread
-		elif self._update_ready == None:
+		elif self._update_ready is None:
 			self.start_async_check_update(False, callback)
-
 
 	def check_for_update_now(self, callback=None):
 
@@ -1175,15 +1205,15 @@ class Singleton_updater(object):
 
 		if self._verbose:
 			print("Check update pressed, first getting current status")
-		if self._async_checking == True:
-			if self._verbose: print("Skipping async check, already started")
+		if self._async_checking:
+			if self._verbose:
+				print("Skipping async check, already started")
 			return  # already running the bg thread
-		elif self._update_ready == None:
+		elif self._update_ready is None:
 			self.start_async_check_update(True, callback)
 		else:
 			self._update_ready = None
 			self.start_async_check_update(True, callback)
-
 
 	# this function is not async, will always return in sequential fashion
 	# but should have a parent which calls it in another thread
@@ -1196,26 +1226,28 @@ class Singleton_updater(object):
 
 		# avoid running again in, just return past result if found
 		# but if force now check, then still do it
-		if self._update_ready != None and now == False:
-			return (self._update_ready,self._update_version,self._update_link)
+		if self._update_ready is not None and not now:
+			return (self._update_ready, self._update_version, self._update_link)
 
-		if self._current_version == None:
+		if self._current_version is None:
 			raise ValueError("current_version not yet defined")
-		if self._repo == None:
+
+		if self._repo is None:
 			raise ValueError("repo not yet defined")
-		if self._user == None:
+
+		if self._user is None:
 			raise ValueError("username not yet defined")
 
 		self.set_updater_json()  # self._json
 
-		if now == False and self.past_interval_timestamp()==False:
+		if not now and self.past_interval_timestamp()==False:
 			if self._verbose:
 				print("Aborting check for updated, check interval not reached")
 			return (False, None, None)
 
 		# check if using tags or releases
 		# note that if called the first time, this will pull tags from online
-		if self._fake_install == True:
+		if self._fake_install:
 			if self._verbose:
 				print("fake_install = True, setting fake version as ready")
 			self._update_ready = True
@@ -1233,16 +1265,17 @@ class Singleton_updater(object):
 		# can be () or ('master') in addition to branches, and version tag
 		new_version = self.version_tuple_from_text(self.tag_latest)
 
-		if len(self._tags)==0:
+		if len(self._tags) == 0:
 			self._update_ready = False
 			self._update_version = None
 			self._update_link = None
 			return (False, None, None)
-		if self._include_branches == False:
+
+		if not self._include_branches:
 			link = self.select_link(self, self._tags[0])
 		else:
 			n = len(self._include_branch_list)
-			if len(self._tags)==n:
+			if len(self._tags) == n:
 				# effectively means no tags found on repo
 				# so provide the first one as default
 				link = self.select_link(self, self._tags[0])
@@ -1258,7 +1291,7 @@ class Singleton_updater(object):
 			# handle situation where master/whichever branch is included
 			# however, this code effectively is not triggered now
 			# as new_version will only be tag names, not branch names
-			if self._include_branch_autocheck == False:
+			if not self._include_branch_autocheck:
 				# don't offer update as ready,
 				# but set the link for the default
 				# branch for installing
@@ -1297,7 +1330,6 @@ class Singleton_updater(object):
 		self._update_link = None
 		return (False, None, None)
 
-
 	def set_tag(self, name):
 		"""Assign the tag name and url to update to"""
 		tg = None
@@ -1318,8 +1350,7 @@ class Singleton_updater(object):
 		if not tg:
 			raise ValueError("Version tag not found: "+name)
 
-
-	def run_update(self,force=False,revert_tag=None,clean=False,callback=None):
+	def run_update(self, force=False, revert_tag=None, clean=False, callback=None):
 		"""Runs an install, update, or reversion of an addon from online source
 
 		Arguments:
@@ -1332,7 +1363,7 @@ class Singleton_updater(object):
 		self._json["ignore"] = False  # clear ignore flag
 		self._json["version_text"] = {}
 
-		if revert_tag != None:
+		if revert_tag is not None:
 			self.set_tag(revert_tag)
 			self._update_ready = True
 
@@ -1342,21 +1373,21 @@ class Singleton_updater(object):
 
 		if self._verbose: print("Running update")
 
-		if self._fake_install == True:
+		if self._fake_install:
 			# change to True, to trigger the reload/"update installed" handler
 			if self._verbose:
 				print("fake_install=True")
 				print("Just reloading and running any handler triggers")
 			self._json["just_updated"] = True
 			self.save_updater_json()
-			if self._backup_current == True:
+			if self._backup_current is True:
 				self.create_backup()
 			self.reload_addon()
 			self._update_ready = False
 			res = True  # fake "success" zip download flag
 
-		elif force==False:
-			if self._update_ready != True:
+		elif not force:
+			if not self._update_ready:
 				if self._verbose:
 					print("Update stopped, new version not ready")
 				if callback:
@@ -1364,7 +1395,7 @@ class Singleton_updater(object):
 						self._addon_package,
 						"Update stopped, new version not ready")
 				return "Update stopped, new version not ready"
-			elif self._update_link == None:
+			elif self._update_link is None:
 				# this shouldn't happen if update is ready
 				if self._verbose:
 					print("Update stopped, update link unavailable")
@@ -1374,15 +1405,15 @@ class Singleton_updater(object):
 						"Update stopped, update link unavailable")
 				return "Update stopped, update link unavailable"
 
-			if self._verbose and revert_tag==None:
+			if self._verbose and revert_tag is None:
 				print("Staging update")
 			elif self._verbose:
 				print("Staging install")
 
 			res = self.stage_repository(self._update_link)
-			if res !=True:
-				print("Error in staging repository: "+str(res))
-				if callback != None:
+			if not res:
+				print("Error in staging repository: " + str(res))
+				if callback is not None:
 					callback(self._addon_package, self._error_msg)
 				return self._error_msg
 			res = self.unpack_staged_zip(clean)
@@ -1392,7 +1423,7 @@ class Singleton_updater(object):
 				return res
 
 		else:
-			if self._update_link == None:
+			if self._update_link is None:
 				if self._verbose:
 					print("Update stopped, could not get link")
 				return "Update stopped, could not get link"
@@ -1400,13 +1431,13 @@ class Singleton_updater(object):
 				print("Forcing update")
 
 			res = self.stage_repository(self._update_link)
-			if res !=True:
-				print("Error in staging repository: "+str(res))
+			if not res:
+				print("Error in staging repository: " + str(res))
 				if callback:
 					callback(self._addon_package, self._error_msg)
 				return self._error_msg
 			res = self.unpack_staged_zip(clean)
-			if res<0:
+			if res < 0:
 				return res
 			# would need to compare against other versions held in tags
 
@@ -1417,9 +1448,8 @@ class Singleton_updater(object):
 		# return something meaningful, 0 means it worked
 		return 0
 
-
 	def past_interval_timestamp(self):
-		if self._check_interval_enable == False:
+		if not self._check_interval_enable:
 			return True  # ie this exact feature is disabled
 
 		if "last_check" not in self._json or self._json["last_check"] == "":
@@ -1467,9 +1497,9 @@ class Singleton_updater(object):
 
 	def set_updater_json(self):
 		"""Load or initialize JSON dictionary data for updater state"""
-		if self._updater_path == None:
+		if self._updater_path is None:
 			raise ValueError("updater_path is not defined")
-		elif os.path.isdir(self._updater_path) == False:
+		elif not os.path.isdir(self._updater_path):
 			os.makedirs(self._updater_path)
 
 		jpath = self.get_json_path()
@@ -1482,24 +1512,23 @@ class Singleton_updater(object):
 		else:
 			# set data structure
 			self._json = {
-				"last_check":"",
-				"backup_date":"",
-				"update_ready":False,
-				"ignore":False,
-				"just_restored":False,
-				"just_updated":False,
-				"version_text":{}
+				"last_check": "",
+				"backup_date": "",
+				"update_ready": False,
+				"ignore": False,
+				"just_restored": False,
+				"just_updated": False,
+				"version_text": {}
 			}
 			self.save_updater_json()
 
-
 	def save_updater_json(self):
 		# first save the state
-		if self._update_ready == True:
-			if type(self._update_version) == type((0,0,0)):
+		if self._update_ready:
+			if type(self._update_version) == type((0, 0, 0)):
 				self._json["update_ready"] = True
-				self._json["version_text"]["link"]=self._update_link
-				self._json["version_text"]["version"]=self._update_version
+				self._json["version_text"]["link"] = self._update_link
+				self._json["version_text"]["version"] = self._update_version
 			else:
 				self._json["update_ready"] = False
 				self._json["version_text"] = {}
@@ -1508,7 +1537,7 @@ class Singleton_updater(object):
 			self._json["version_text"] = {}
 
 		jpath = self.get_json_path()
-		outf = open(jpath,'w')
+		outf = open(jpath, 'w')
 		data_out = json.dumps(self._json, indent=4)
 		outf.write(data_out)
 		outf.close()
@@ -1533,14 +1562,12 @@ class Singleton_updater(object):
 		self._json["ignore"] = True
 		self.save_updater_json()
 
-
 	# -------------------------------------------------------------------------
 	# ASYNC stuff
 	# -------------------------------------------------------------------------
-
 	def start_async_check_update(self, now=False, callback=None):
 		"""Start a background thread which will check for updates"""
-		if self._async_checking is True:
+		if self._async_checking:
 			return
 		if self._verbose:
 			print("{} updater: Starting background checking thread".format(
@@ -1588,7 +1615,7 @@ class Singleton_updater(object):
 		does complete with a successful response, this will be still displayed
 		on next UI refresh (ie no update, or update available).
 		"""
-		if self._check_thread != None:
+		if self._check_thread is not None:
 			if self._verbose: print("Thread will end in normal course.")
 			# however, "There is no direct kill method on a thread object."
 			# better to let it run its course
@@ -1627,7 +1654,7 @@ class BitbucketEngine(object):
 			name=name)
 
 	def parse_tags(self, response, updater):
-		if response == None:
+		if response is None:
 			return []
 		return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["name"], updater)} for tag in response["values"]]
 
@@ -1641,24 +1668,24 @@ class GithubEngine(object):
 		self.name = "github"
 
 	def form_repo_url(self, updater):
-		return "{}{}{}{}{}".format(self.api_url,"/repos/",updater.user,
-								"/",updater.repo)
+		return "{}{}{}{}{}".format(self.api_url, "/repos/", updater.user, "/",
+								   updater.repo)
 
 	def form_tags_url(self, updater):
 		if updater.use_releases:
-			return "{}{}".format(self.form_repo_url(updater),"/releases")
+			return "{}{}".format(self.form_repo_url(updater), "/releases")
 		else:
-			return "{}{}".format(self.form_repo_url(updater),"/tags")
+			return "{}{}".format(self.form_repo_url(updater), "/tags")
 
 	def form_branch_list_url(self, updater):
-		return "{}{}".format(self.form_repo_url(updater),"/branches")
+		return "{}{}".format(self.form_repo_url(updater), "/branches")
 
 	def form_branch_url(self, branch, updater):
-		return "{}{}{}".format(self.form_repo_url(updater),
-							"/zipball/",branch)
+		return "{}{}{}".format(self.form_repo_url(updater), "/zipball/",
+							   branch)
 
 	def parse_tags(self, response, updater):
-		if response == None:
+		if response is None:
 			return []
 		return response
 
@@ -1672,16 +1699,15 @@ class GitlabEngine(object):
 		self.name = "gitlab"
 
 	def form_repo_url(self, updater):
-		return "{}{}{}".format(self.api_url,"/api/v4/projects/",updater.repo)
+		return "{}{}{}".format(self.api_url, "/api/v4/projects/", updater.repo)
 
 	def form_tags_url(self, updater):
-		return "{}{}".format(self.form_repo_url(updater),"/repository/tags")
+		return "{}{}".format(self.form_repo_url(updater), "/repository/tags")
 
 	def form_branch_list_url(self, updater):
 		# does not validate branch name.
 		return "{}{}".format(
-			self.form_repo_url(updater),
-			"/repository/branches")
+			self.form_repo_url(updater), "/repository/branches")
 
 	def form_branch_url(self, branch, updater):
 		# Could clash with tag names and if it does, it will
@@ -1701,7 +1727,7 @@ class GitlabEngine(object):
 	# 	return self.form_repo_url(updater)+"/repository/archive.zip?sha:"+id
 
 	def parse_tags(self, response, updater):
-		if response == None:
+		if response is None:
 			return []
 		return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["commit"]["id"], updater)} for tag in response]
 

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -234,11 +234,12 @@ class SingletonUpdater:
 
     @engine.setter
     def engine(self, value):
-        if value.lower() is "github":
+        engine = value.lower()
+        if engine == "github":
             self._engine = GithubEngine()
-        elif value.lower() is "gitlab":
+        elif engine == "gitlab":
             self._engine = GitlabEngine()
-        elif value.lower() is "bitbucket":
+        elif engine == "bitbucket":
             self._engine = BitbucketEngine()
         else:
             raise ValueError("Invalid engine selection")

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -1183,14 +1183,15 @@ class SingletonUpdater:
     # called for running check in a background thread
     def check_for_update_async(self, callback=None):
 
-        if self._json is not None and "update_ready" in self._json and self._json["version_text"] != dict():
-            if self._json["update_ready"]:
-                self._update_ready = True
-                self._update_link = self._json["version_text"]["link"]
-                self._update_version = str(self._json["version_text"]["version"])
-                # cached update
-                callback(True)
-                return
+        is_ready = self._json is not None and "update_ready" in self._json and \
+                 self._json["version_text"] != dict() and self._json["update_ready"]
+        if is_ready:
+            self._update_ready = True
+            self._update_link = self._json["version_text"]["link"]
+            self._update_version = str(self._json["version_text"]["version"])
+            # cached update
+            callback(True)
+            return
 
         # do the check
         if not self._check_interval_enabled:

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -181,7 +181,6 @@ class SingletonUpdater:
     def backup_current(self, value):
         if value is None:
             self._backup_current = False
-            return
         else:
             self._backup_current = value
 
@@ -193,7 +192,6 @@ class SingletonUpdater:
     def backup_ignore_patterns(self, value):
         if value is None:
             self._backup_ignore_patterns = None
-            return
         elif not isinstance(value, list):
             raise ValueError("Backup pattern must be in list format")
         else:
@@ -220,12 +218,10 @@ class SingletonUpdater:
             try:
                 tuple(tuple_values)
             except:
-                raise ValueError(
-                    "Not a tuple! current_version must be a tuple of integers")
+                raise ValueError("Not a tuple! current_version must be a tuple of integers")
         for i in tuple_values:
             if type(i) is not int:
-                raise ValueError(
-                    "Not an integer! current_version must be a tuple of integers")
+                raise ValueError("Not an integer! current_version must be a tuple of integers")
         self._current_version = tuple(tuple_values)
 
     @property
@@ -628,7 +624,7 @@ class SingletonUpdater:
             # some error occurred
             self._tag_latest = None
             self._tags = list()
-            return
+
         elif self._prefiltered_tag_count == 0 and not self._include_branches:
             self._tag_latest = None
             if self._error is None:  # if not None, could have had no internet
@@ -636,12 +632,14 @@ class SingletonUpdater:
                 self._error_msg = "No releases or tags found on this repository"
             if self._verbose:
                 print("No releases or tags found on this repository")
+
         elif self._prefiltered_tag_count == 0 and self._include_branches:
             if not self._error:
                 self._tag_latest = self._tags[0]
             if self._verbose:
                 branch = self._include_branch_list[0]
                 print("{} branch found, no releases".format(branch), self._tags[0])
+
         elif (len(self._tags) - len(self._include_branch_list) == 0 and self._include_branches) \
                 or (len(self._tags) == 0 and not self._include_branches) \
                 and self._prefiltered_tag_count > 0:
@@ -650,6 +648,7 @@ class SingletonUpdater:
             self._error_msg = "No versions found within compatible version range"
             if self._verbose:
                 print("No versions found within compatible version range")
+
         else:
             if not self._include_branches:
                 self._tag_latest = self._tags[0]
@@ -811,8 +810,7 @@ class SingletonUpdater:
         if self._verbose:
             print("Backing up current addon folder")
         local = os.path.join(self._updater_path, "backup")
-        tempdest = os.path.join(self._addon_root, os.pardir,
-                                self._addon + "_updater_backup_temp")
+        tempdest = os.path.join(self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
 
         if self._verbose:
             print("Backup destination path: ", local)
@@ -856,8 +854,7 @@ class SingletonUpdater:
         if self._verbose:
             print("Backing up current addon folder")
         backuploc = os.path.join(self._updater_path, "backup")
-        tempdest = os.path.join(self._addon_root, os.pardir,
-                        self._addon + "_updater_backup_temp")
+        tempdest = os.path.join(self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
         tempdest = os.path.abspath(tempdest)
 
         # make the copy
@@ -1409,8 +1406,7 @@ class SingletonUpdater:
                 if self._verbose:
                     print("Update stopped, update link unavailable")
                 if callback:
-                    callback(self._addon_package,
-                        "Update stopped, update link unavailable")
+                    callback(self._addon_package, "Update stopped, update link unavailable")
                 return "Update stopped, update link unavailable"
 
             if self._verbose and revert_tag is None:

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -90,7 +90,7 @@ class SingletonUpdater:
         self._auto_reload_post_update = False
 
         # settings relating to frequency and whether to enable auto background check
-        self._check_interval_enable = False
+        self._check_interval_enabled = False
         self._check_interval_months = 0
         self._check_interval_days = 7
         self._check_interval_hours = 0
@@ -199,7 +199,7 @@ class SingletonUpdater:
 
     @property
     def check_interval(self):
-        return (self._check_interval_enable,
+        return (self._check_interval_enabled,
                 self._check_interval_months,
                 self._check_interval_days,
                 self._check_interval_hours,
@@ -557,9 +557,9 @@ class SingletonUpdater:
             raise ValueError("Minutes must be an integer value")
 
         if not enabled:
-            self._check_interval_enable = False
+            self._check_interval_enabled = False
         else:
-            self._check_interval_enable = True
+            self._check_interval_enabled = True
 
         self._check_interval_months = months
         self._check_interval_days = days
@@ -1183,7 +1183,7 @@ class SingletonUpdater:
     # called for running check in a background thread
     def check_for_update_async(self, callback=None):
 
-        if self._json is not None and "update_ready" in self._json and self._json["version_text"] is not dict():
+        if self._json is not None and "update_ready" in self._json and self._json["version_text"] != dict():
             if self._json["update_ready"]:
                 self._update_ready = True
                 self._update_link = self._json["version_text"]["link"]
@@ -1193,12 +1193,12 @@ class SingletonUpdater:
                 return
 
         # do the check
-        if not self._check_interval_enable:
+        if not self._check_interval_enabled:
             return
         elif self._async_checking:
             if self._verbose:
                 print("Skipping async check, already started")
-            return  # already running the bg thread
+            # already running the bg thread
         elif self._update_ready is None:
             self.start_async_check_update(False, callback)
 
@@ -1453,7 +1453,7 @@ class SingletonUpdater:
         return 0
 
     def past_interval_timestamp(self):
-        if not self._check_interval_enable:
+        if not self._check_interval_enabled:
             return True  # ie this exact feature is disabled
 
         if "last_check" not in self._json or self._json["last_check"] == "":

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -53,1585 +53,1582 @@ DEFAULT_PER_PAGE = 30  # currently not used
 # The main class
 # -----------------------------------------------------------------------------
 class SingletonUpdater:
-	"""
-	This is the singleton class to reference a copy from,
-	it is the shared module level class
-	"""
-	def __init__(self):
-
-		self._engine = GithubEngine()
-		self._user = None
-		self._repo = None
-		self._website = None
-		self._current_version = None
-		self._subfolder_path = None
-		self._tags = list()
-		self._tag_latest = None
-		self._tag_names = list()
-		self._latest_release = None
-		self._use_releases = False
-		self._include_branches = False
-		self._include_branch_list = ['master']
-		self._include_branch_auto_check = False
-		self._manual_only = False
-		self._version_min_update = None
-		self._version_max_update = None
-
-		# by default, backup current addon if new is being loaded
-		self._backup_current = True
-		self._backup_ignore_patterns = None
-
-		# set patterns for what files to overwrite on update
-		self._overwrite_patterns = ["*.py", "*.pyc"]
-		self._remove_pre_update_patterns = list()
-
-		# by default, don't auto enable/disable the addon on update
-		# as it is slightly less stable/won't always fully reload module
-		self._auto_reload_post_update = False
-
-		# settings relating to frequency and whether to enable auto background check
-		self._check_interval_enable = False
-		self._check_interval_months = 0
-		self._check_interval_days = 7
-		self._check_interval_hours = 0
-		self._check_interval_minutes = 0
-
-		# runtime variables, initial conditions
-		self._verbose = False
-		self._use_print_traces = True
-		self._fake_install = False
-		self._async_checking = False  # only true when async daemon started
-		self._update_ready = None
-		self._update_link = None
-		self._update_version = None
-		self._source_zip = None
-		self._check_thread = None
-		self._select_link = None
-		self.skip_tag = None
-
-		# get from module data
-		self._addon = __package__.lower()
-		self._addon_package = __package__  # must not change
-		self._updater_path = os.path.join(os.path.dirname(__file__),
-										self._addon + "_updater")
-		self._addon_root = os.path.dirname(__file__)
-		self._json = dict()
-		self._error = None
-		self._error_msg = None
-		self._prefiltered_tag_count = 0
-
-		# UI code only, ie not used within this module but still useful
-		# properties to have
-
-		# to verify a valid import, in place of placeholder import
-		self.show_popups = True  # used in UI to show or not show update popups
-		self.invalid_updater = False
-
-		# pre-assign basic select-link function
-		def select_link_function(self, tag):
-			return tag["zipball_url"]
-
-		self._select_link = select_link_function
-
-	def print_trace(self):
-		"""Print handled exception details when use_print_traces is set"""
-		if self._use_print_traces:
-			traceback.print_exc()
-
-	# -------------------------------------------------------------------------
-	# Getters and setters
-	# -------------------------------------------------------------------------
-	@property
-	def addon(self):
-		return self._addon
-
-	@addon.setter
-	def addon(self, value):
-		self._addon = str(value)
-
-	@property
-	def api_url(self):
-		return self._engine.api_url
-
-	@api_url.setter
-	def api_url(self, value):
-		if not self.check_is_url(value):
-			raise ValueError("Not a valid URL: " + value)
-		self._engine.api_url = value
-
-	@property
-	def async_checking(self):
-		return self._async_checking
-
-	@property
-	def auto_reload_post_update(self):
-		return self._auto_reload_post_update
-
-	@auto_reload_post_update.setter
-	def auto_reload_post_update(self, value):
-		try:
-			self._auto_reload_post_update = bool(value)
-		except:
-			raise ValueError("auto_reload_post_update must be a boolean value")
-
-	@property
-	def backup_current(self):
-		return self._backup_current
-
-	@backup_current.setter
-	def backup_current(self, value):
-		if value is None:
-			self._backup_current = False
-			return
-		else:
-			self._backup_current = value
-
-	@property
-	def backup_ignore_patterns(self):
-		return self._backup_ignore_patterns
-
-	@backup_ignore_patterns.setter
-	def backup_ignore_patterns(self, value):
-		if value is None:
-			self._backup_ignore_patterns = None
-			return
-		elif not isinstance(value, list):
-			raise ValueError("Backup pattern must be in list format")
-		else:
-			self._backup_ignore_patterns = value
-
-	@property
-	def check_interval(self):
-		return (self._check_interval_enable,
-				self._check_interval_months,
-				self._check_interval_days,
-				self._check_interval_hours,
-				self._check_interval_minutes)
-
-	@property
-	def current_version(self):
-		return self._current_version
-
-	@current_version.setter
-	def current_version(self, tuple_values):
-		if tuple_values is None:
-			self._current_version = None
-			return
-		elif type(tuple_values) is not tuple:
-			try:
-				tuple(tuple_values)
-			except:
-				raise ValueError(
-					"Not a tuple! current_version must be a tuple of integers")
-		for i in tuple_values:
-			if type(i) is not int:
-				raise ValueError(
-					"Not an integer! current_version must be a tuple of integers")
-		self._current_version = tuple(tuple_values)
-
-	@property
-	def engine(self):
-		return self._engine.name
-
-	@engine.setter
-	def engine(self, value):
-		if value.lower() is "github":
-			self._engine = GithubEngine()
-		elif value.lower() is "gitlab":
-			self._engine = GitlabEngine()
-		elif value.lower() is "bitbucket":
-			self._engine = BitbucketEngine()
-		else:
-			raise ValueError("Invalid engine selection")
-
-	@property
-	def error(self):
-		return self._error
-
-	@property
-	def error_msg(self):
-		return self._error_msg
-
-	@property
-	def fake_install(self):
-		return self._fake_install
-
-	@fake_install.setter
-	def fake_install(self, value):
-		if not isinstance(value, bool):
-			raise ValueError("fake_install must be a boolean value")
-		self._fake_install = bool(value)
-
-	# not currently used
-	@property
-	def include_branch_auto_check(self):
-		return self._include_branch_auto_check
-
-	@include_branch_auto_check.setter
-	def include_branch_auto_check(self, value):
-		try:
-			self._include_branch_auto_check = bool(value)
-		except:
-			raise ValueError("include_branch_autocheck must be a boolean value")
-
-	@property
-	def include_branch_list(self):
-		return self._include_branch_list
-
-	@include_branch_list.setter
-	def include_branch_list(self, value):
-		try:
-			if value is None:
-				self._include_branch_list = ['master']
-			elif not isinstance(value, list) or len(value) == 0:
-				raise ValueError("include_branch_list should be a list of valid branches")
-			else:
-				self._include_branch_list = value
-		except:
-			raise ValueError("include_branch_list should be a list of valid branches")
-
-	@property
-	def include_branches(self):
-		return self._include_branches
-
-	@include_branches.setter
-	def include_branches(self, value):
-		try:
-			self._include_branches = bool(value)
-		except:
-			raise ValueError("include_branches must be a boolean value")
-
-	@property
-	def json(self):
-		if len(self._json) == 0:
-			self.set_updater_json()
-		return self._json
-
-	@property
-	def latest_release(self):
-		if self._latest_release is None:
-			return None
-		return self._latest_release
-
-	@property
-	def manual_only(self):
-		return self._manual_only
-
-	@manual_only.setter
-	def manual_only(self, value):
-		try:
-			self._manual_only = bool(value)
-		except:
-			raise ValueError("manual_only must be a boolean value")
-
-	@property
-	def overwrite_patterns(self):
-		return self._overwrite_patterns
-
-	@overwrite_patterns.setter
-	def overwrite_patterns(self, value):
-		if value is None:
-			self._overwrite_patterns = ["*.py", "*.pyc"]
-		elif not isinstance(value, list):
-			raise ValueError("overwrite_patterns needs to be in a list format")
-		else:
-			self._overwrite_patterns = value
-
-	@property
-	def private_token(self):
-		return self._engine.token
-
-	@private_token.setter
-	def private_token(self, value):
-		if value is None:
-			self._engine.token = None
-		else:
-			self._engine.token = str(value)
-
-	@property
-	def remove_pre_update_patterns(self):
-		return self._remove_pre_update_patterns
-
-	@remove_pre_update_patterns.setter
-	def remove_pre_update_patterns(self, value):
-		if value is None:
-			self._remove_pre_update_patterns = list()
-		elif not isinstance(value, list):
-			raise ValueError("remove_pre_update_patterns needs to be in a list format")
-		else:
-			self._remove_pre_update_patterns = value
-
-	@property
-	def repo(self):
-		return self._repo
-
-	@repo.setter
-	def repo(self, value):
-		try:
-			self._repo = str(value)
-		except:
-			raise ValueError("repo must be a string value")
-
-	@property
-	def select_link(self):
-		return self._select_link
-
-	@select_link.setter
-	def select_link(self, value):
-		# ensure it is a function assignment, with signature:
-		# input self, tag; returns link name
-		if not hasattr(value, "__call__"):
-			raise ValueError("select_link must be a function")
-		self._select_link = value
-
-	@property
-	def stage_path(self):
-		return self._updater_path
-
-	@stage_path.setter
-	def stage_path(self, value):
-		if value is None:
-			if self._verbose:
-				print("Aborting assigning stage_path, it's null")
-			return
-		elif value is not None and not os.path.exists(value):
-			try:
-				os.makedirs(value)
-			except:
-				if self._verbose:
-					print("Error trying to staging path")
-				self.print_trace()
-				return
-		self._updater_path = value
-
-	@property
-	def subfolder_path(self):
-		return self._subfolder_path
-
-	@subfolder_path.setter
-	def subfolder_path(self, value):
-		self._subfolder_path = value
-
-	@property
-	def tags(self):
-		if len(self._tags) == 0:
-			return list()
-		tag_names = list()
-		for tag in self._tags:
-			tag_names.append(tag["name"])
-		return tag_names
-
-	@property
-	def tag_latest(self):
-		if self._tag_latest is None:
-			return None
-		return self._tag_latest["name"]
-
-	@property
-	def update_link(self):
-		return self._update_link
-
-	@property
-	def update_ready(self):
-		return self._update_ready
-
-	@property
-	def update_version(self):
-		return self._update_version
-
-	@property
-	def use_releases(self):
-		return self._use_releases
-
-	@use_releases.setter
-	def use_releases(self, value):
-		try:
-			self._use_releases = bool(value)
-		except:
-			raise ValueError("use_releases must be a boolean value")
-
-	@property
-	def user(self):
-		return self._user
-
-	@user.setter
-	def user(self, value):
-		try:
-			self._user = str(value)
-		except:
-			raise ValueError("User must be a string value")
-
-	@property
-	def verbose(self):
-		return self._verbose
-
-	@verbose.setter
-	def verbose(self, value):
-		try:
-			self._verbose = bool(value)
-			if self._verbose:
-				print(self._addon + " updater verbose is enabled")
-		except:
-			raise ValueError("Verbose must be a boolean value")
-
-	@property
-	def use_print_traces(self):
-		return self._use_print_traces
-
-	@use_print_traces.setter
-	def use_print_traces(self, value):
-		try:
-			self._use_print_traces = bool(value)
-		except:
-			raise ValueError("use_print_traces must be a boolean value")
-
-	@property
-	def version_max_update(self):
-		return self._version_max_update
-
-	@version_max_update.setter
-	def version_max_update(self, value):
-		if value is None:
-			self._version_max_update = None
-			return
-		if not isinstance(value, tuple):
-			raise ValueError("Version maximum must be a tuple")
-		for subvalue in value:
-			if type(subvalue) is not int:
-				raise ValueError("Version elements must be integers")
-		self._version_max_update = value
-
-	@property
-	def version_min_update(self):
-		return self._version_min_update
-
-	@version_min_update.setter
-	def version_min_update(self, value):
-		if value is None:
-			self._version_min_update = None
-			return
-		if not isinstance(value, tuple):
-			raise ValueError("Version minimum must be a tuple")
-		for subvalue in value:
-			if type(subvalue) != int:
-				raise ValueError("Version elements must be integers")
-		self._version_min_update = value
-
-	@property
-	def website(self):
-		return self._website
-
-	@website.setter
-	def website(self, value):
-		if not self.check_is_url(value):
-			raise ValueError("Not a valid URL: " + value)
-		self._website = value
-
-	# -------------------------------------------------------------------------
-	# Parameter validation related functions
-	# -------------------------------------------------------------------------
-	@staticmethod
-	def check_is_url(url):
-		if not ("http://" in url or "https://" in url):
-			return False
-		if "." not in url:
-			return False
-		return True
-
-	def _get_tag_names(self):
-		tag_names = list()
-		self.get_tags()
-		for tag in self._tags:
-			tag_names.append(tag["name"])
-		return tag_names
-
-	def set_check_interval(self, enabled=False, months=0, days=14, hours=0, minutes=0):
-		# enabled = False, default initially will not check against frequency
-		# if enabled, default is then 2 weeks
-
-		if type(enabled) is not bool:
-			raise ValueError("Enable must be a boolean value")
-		if type(months) is not int:
-			raise ValueError("Months must be an integer value")
-		if type(days) is not int:
-			raise ValueError("Days must be an integer value")
-		if type(hours) is not int:
-			raise ValueError("Hours must be an integer value")
-		if type(minutes) is not int:
-			raise ValueError("Minutes must be an integer value")
-
-		if not enabled:
-			self._check_interval_enable = False
-		else:
-			self._check_interval_enable = True
-
-		self._check_interval_months = months
-		self._check_interval_days = days
-		self._check_interval_hours = hours
-		self._check_interval_minutes = minutes
-
-	# declare how the class gets printed
-
-	def __repr__(self):
-		return "<Module updater from {a}>".format(a=__file__)
-
-	def __str__(self):
-		return "Updater, with user: {a}, repository: {b}, url: {c}".format(
-						a=self._user,
-						b=self._repo, c=self.form_repo_url())
-
-	# -------------------------------------------------------------------------
-	# API-related functions
-	# -------------------------------------------------------------------------
-	def form_repo_url(self):
-		return self._engine.form_repo_url(self)
-
-	def form_tags_url(self):
-		return self._engine.form_tags_url(self)
-
-	def form_branch_url(self, branch):
-		return self._engine.form_branch_url(branch, self)
-
-	def get_tags(self):
-		request = self.form_tags_url()
-		if self._verbose:
-			print("Getting tags from server")
-
-		# get all tags, internet call
-		all_tags = self._engine.parse_tags(self.get_api(request), self)
-		if all_tags is not None:
-			self._prefiltered_tag_count = len(all_tags)
-		else:
-			self._prefiltered_tag_count = 0
-			all_tags = list()
-
-		# pre-process to skip tags
-		if self.skip_tag is not None:
-			self._tags = [tg for tg in all_tags if not self.skip_tag(self, tg)]
-		else:
-			self._tags = all_tags
-
-		# get additional branches too, if needed, and place in front
-		# Does NO checking here whether branch is valid
-		if self._include_branches:
-			temp_branches = self._include_branch_list.copy()
-			temp_branches.reverse()
-			for branch in temp_branches:
-				request = self.form_branch_url(branch)
-				include = {
-					"name": branch.title(),
-					"zipball_url": request
-				}
-				self._tags = [include] + self._tags  # append to front
-
-		if self._tags is None:
-			# some error occurred
-			self._tag_latest = None
-			self._tags = list()
-			return
-		elif self._prefiltered_tag_count == 0 and not self._include_branches:
-			self._tag_latest = None
-			if self._error is None:  # if not None, could have had no internet
-				self._error = "No releases found"
-				self._error_msg = "No releases or tags found on this repository"
-			if self._verbose:
-				print("No releases or tags found on this repository")
-		elif self._prefiltered_tag_count == 0 and self._include_branches:
-			if not self._error:
-				self._tag_latest = self._tags[0]
-			if self._verbose:
-				branch = self._include_branch_list[0]
-				print("{} branch found, no releases".format(branch), self._tags[0])
-		elif (len(self._tags) - len(self._include_branch_list) == 0 and self._include_branches) \
-				or (len(self._tags) == 0 and not self._include_branches) \
-				and self._prefiltered_tag_count > 0:
-			self._tag_latest = None
-			self._error = "No releases available"
-			self._error_msg = "No versions found within compatible version range"
-			if self._verbose:
-				print("No versions found within compatible version range")
-		else:
-			if not self._include_branches:
-				self._tag_latest = self._tags[0]
-				if self._verbose:
-					print("Most recent tag found:", self._tags[0]['name'])
-			else:
-				# don't return branch if in list
-				n = len(self._include_branch_list)
-				self._tag_latest = self._tags[n]  # guaranteed at least len()=n+1
-				if self._verbose:
-					print("Most recent tag found:", self._tags[n]['name'])
-
-	# all API calls to base url
-	def get_raw(self, url):
-		# print("Raw request:", url)
-		request = urllib.request.Request(url)
-		try:
-			context = ssl._create_unverified_context()
-		except:
-			# some blender packaged python versions don't have this, largely
-			# useful for local network setups otherwise minimal impact
-			context = None
-
-		# setup private request headers if appropriate
-		if self._engine.token is not None:
-			if self._engine.name == "gitlab":
-				request.add_header('PRIVATE-TOKEN', self._engine.token)
-			else:
-				if self._verbose:
-					print("Tokens not setup for engine yet")
-
-		# Always set user agent
-		request.add_header('User-Agent', "Python/" + str(platform.python_version()))
-
-		# run the request
-		try:
-			if context:
-				result = urllib.request.urlopen(request, context=context)
-			else:
-				result = urllib.request.urlopen(request)
-		except urllib.error.HTTPError as e:
-			if str(e.code) == "403":
-				self._error = "HTTP error (access denied)"
-				self._error_msg = str(e.code) + " - server error response"
-				print(self._error, self._error_msg)
-			else:
-				self._error = "HTTP error"
-				self._error_msg = str(e.code)
-				print(self._error, self._error_msg)
-			self.print_trace()
-			self._update_ready = None
-		except urllib.error.URLError as e:
-			reason = str(e.reason)
-			if "TLSV1_ALERT" in reason or "SSL" in reason.upper():
-				self._error = "Connection rejected, download manually"
-				self._error_msg = reason
-				print(self._error, self._error_msg)
-			else:
-				self._error = "URL error, check internet connection"
-				self._error_msg = reason
-				print(self._error, self._error_msg)
-			self.print_trace()
-			self._update_ready = None
-			return None
-		else:
-			result_string = result.read()
-			result.close()
-			return result_string.decode()
-
-	# result of all api calls, decoded into json format
-	def get_api(self, url):
-		# return the json version
-		get = None
-		get = self.get_raw(url)
-		if get is not None:
-			try:
-				return json.JSONDecoder().decode(get)
-			except Exception as e:
-				self._error = "API response has invalid JSON format"
-				self._error_msg = str(e.reason)
-				self._update_ready = None
-				print(self._error, self._error_msg)
-				self.print_trace()
-				return None
-		else:
-			return None
-
-	# create a working directory and download the new files
-	def stage_repository(self, url):
-
-		local = os.path.join(self._updater_path, "update_staging")
-		error = None
-
-		# make/clear the staging folder
-		# ensure the folder is always "clean"
-		if self._verbose:
-			print("Preparing staging folder for download:\n", local)
-		if os.path.isdir(local):
-			try:
-				shutil.rmtree(local)
-				os.makedirs(local)
-			except:
-				error = "failed to remove existing staging directory"
-				self.print_trace()
-		else:
-			try:
-				os.makedirs(local)
-			except:
-				error = "failed to create staging directory"
-				self.print_trace()
-
-		if error is not None:
-			if self._verbose:
-				print("Error: Aborting update, " + error)
-			self._error = "Update aborted, staging path error"
-			self._error_msg = "Error: {}".format(error)
-			return False
-
-		if self._backup_current:
-			self.create_backup()
-
-		if self._verbose:
-			print("Now retrieving the new source zip")
-
-		self._source_zip = os.path.join(local, "source.zip")
-
-		if self._verbose:
-			print("Starting download update zip")
-		try:
-			request = urllib.request.Request(url)
-			context = ssl._create_unverified_context()
-
-			# setup private token if appropriate
-			if self._engine.token is not None:
-				if self._engine.name == "gitlab":
-					request.add_header('PRIVATE-TOKEN', self._engine.token)
-				else:
-					if self._verbose:
-						print("Tokens not setup for selected engine yet")
-
-			# Always set user agent
-			request.add_header('User-Agent', "Python/" + str(platform.python_version()))
-
-			self.url_retrieve(urllib.request.urlopen(request, context=context), self._source_zip)
-			# add additional checks on file size being non-zero
-			if self._verbose:
-				print("Successfully downloaded update zip")
-			return True
-		except Exception as e:
-			self._error = "Error retrieving download, bad link?"
-			self._error_msg = "Error: {}".format(e)
-			if self._verbose:
-				print("Error retrieving download, bad link?")
-				print("Error: {}".format(e))
-			self.print_trace()
-			return False
-
-	def create_backup(self):
-		if self._verbose:
-			print("Backing up current addon folder")
-		local = os.path.join(self._updater_path, "backup")
-		tempdest = os.path.join(self._addon_root, os.pardir,
-								self._addon + "_updater_backup_temp")
-
-		if self._verbose:
-			print("Backup destination path: ", local)
-
-		if os.path.isdir(local):
-			try:
-				shutil.rmtree(local)
-			except:
-				if self._verbose:
-					print("Failed to removed previous backup folder, continuing")
-				self.print_trace()
-
-		# remove the temp folder; shouldn't exist but could if previously interrupted
-		if os.path.isdir(tempdest):
-			try:
-				shutil.rmtree(tempdest)
-			except:
-				if self._verbose:
-					print("Failed to remove existing temp folder, continuing")
-				self.print_trace()
-
-		# make the full addon copy, which temporarily places outside the addon folder
-		if self._backup_ignore_patterns is not None:
-			shutil.copytree(
-				self._addon_root, tempdest,
-				ignore=shutil.ignore_patterns(*self._backup_ignore_patterns))
-		else:
-			shutil.copytree(self._addon_root, tempdest)
-		shutil.move(tempdest, local)
-
-		# save the date for future ref
-		now = datetime.now()
-		self._json["backup_date"] = "{m}-{d}-{yr}".format(
-				m=now.strftime("%B"), d=now.day, yr=now.year)
-		self.save_updater_json()
-
-	def restore_backup(self):
-		if self._verbose:
-			print("Restoring backup")
-
-		if self._verbose:
-			print("Backing up current addon folder")
-		backuploc = os.path.join(self._updater_path, "backup")
-		tempdest = os.path.join(self._addon_root, os.pardir,
-						self._addon + "_updater_backup_temp")
-		tempdest = os.path.abspath(tempdest)
-
-		# make the copy
-		shutil.move(backuploc, tempdest)
-		shutil.rmtree(self._addon_root)
-		os.rename(tempdest, self._addon_root)
-
-		self._json["backup_date"] = ""
-		self._json["just_restored"] = True
-		self._json["just_updated"] = True
-		self.save_updater_json()
-
-		self.reload_addon()
-
-	def unpack_staged_zip(self, clean=False):
-		"""Unzip the downloaded file, and validate contents"""
-		if not os.path.isfile(self._source_zip):
-			if self._verbose:
-				print("Error, update zip not found")
-			self._error = "Install failed"
-			self._error_msg = "Downloaded zip not found"
-			return -1
-
-		# clear the existing source folder in case previous files remain
-		outdir = os.path.join(self._updater_path, "source")
-		try:
-			shutil.rmtree(outdir)
-			if self._verbose:
-				print("Source folder cleared")
-		except:
-			self.print_trace()
-
-		# Create parent directories if needed, would not be relevant unless
-		# installing addon into another location or via an addon manager
-		try:
-			os.mkdir(outdir)
-		except Exception as err:
-			print("Error occurred while making extract dir:")
-			print(str(err))
-			self.print_trace()
-			self._error = "Install failed"
-			self._error_msg = "Failed to make extract directory"
-			return -1
-
-		if not os.path.isdir(outdir):
-			print("Failed to create source directory")
-			self._error = "Install failed"
-			self._error_msg = "Failed to create extract directory"
-			return -1
-
-		if self._verbose:
-			print("Begin extracting source from zip:", self._source_zip)
-		zfile = zipfile.ZipFile(self._source_zip, "r")
-
-		if not zfile:
-			if self._verbose:
-				print("Resulting file is not a zip, cannot extract")
-			self._error = "Install failed"
-			self._error_msg = "Resulting file is not a zip, cannot extract"
-			return -1
-
-		# Now extract directly from the first subfolder (not root)
-		# this avoids adding the first subfolder to the path length,
-		# which can be too long if the download has the SHA in the name
-		zsep = '/'  # os.sep  # might just always be / even on windows
-		for name in zfile.namelist():
-			if zsep not in name:
-				continue
-			top_folder = name[:name.index(zsep) + 1]
-			if name == top_folder + zsep:
-				continue  # skip top level folder
-			sub_path = name[name.index(zsep) + 1:]
-			if name.endswith(zsep):
-				try:
-					os.mkdir(os.path.join(outdir, sub_path))
-					if self._verbose:
-						print("Extract - mkdir: ", os.path.join(outdir, sub_path))
-				except OSError as exc:
-					if exc.errno != errno.EEXIST:
-						self._error = "Install failed"
-						self._error_msg = "Could not create folder from zip"
-						self.print_trace()
-						return -1
-			else:
-				with open(os.path.join(outdir, sub_path), "wb") as outfile:
-					data = zfile.read(name)
-					outfile.write(data)
-					if self._verbose:
-						print("Extract - create:", os.path.join(outdir, sub_path))
-
-		if self._verbose:
-			print("Extracted source")
-
-		unpath = os.path.join(self._updater_path, "source")
-		if not os.path.isdir(unpath):
-			self._error = "Install failed"
-			self._error_msg = "Extracted path does not exist"
-			print("Extracted path does not exist: ", unpath)
-			return -1
-
-		if self._subfolder_path:
-			self._subfolder_path.replace('/', os.path.sep)
-			self._subfolder_path.replace('\\', os.path.sep)
-
-		# either directly in root of zip/one subfolder, or use specified path
-		if not os.path.isfile(os.path.join(unpath, "__init__.py")):
-			dirlist = os.listdir(unpath)
-			if len(dirlist) > 0:
-				if self._subfolder_path == "" or self._subfolder_path is None:
-					unpath = os.path.join(unpath, dirlist[0])
-				else:
-					unpath = os.path.join(unpath, self._subfolder_path)
-
-			# smarter check for additional sub folders for a single folder
-			# containing __init__.py
-			if not os.path.isfile(os.path.join(unpath, "__init__.py")):
-				if self._verbose:
-					print("not a valid addon found")
-					print("Paths:")
-					print(dirlist)
-				self._error = "Install failed"
-				self._error_msg = "No __init__ file found in new source"
-				return -1
-
-		# merge code with running addon directory, using blender default behavior
-		# plus any modifiers indicated by user (e.g. force remove/keep)
-		self.deep_merge_directory(self._addon_root, unpath, clean)
-
-		# Now save the json state
-		#  Change to True, to trigger the handler on other side
-		#  if allowing reloading within same blender instance
-		self._json["just_updated"] = True
-		self.save_updater_json()
-		self.reload_addon()
-		self._update_ready = False
-		return 0
-
-	def deep_merge_directory(self, base, merger, clean=False):
-		"""Merge folder 'merger' into folder 'base' without deleting existing"""
-		if not os.path.exists(base):
-			if self._verbose:
-				print("Base path does not exist:", base)
-			return -1
-		elif not os.path.exists(merger):
-			if self._verbose:
-				print("Merger path does not exist")
-			return -1
-
-		# paths to be aware of and not overwrite/remove/etc
-		staging_path = os.path.join(self._updater_path, "update_staging")
-		backup_path = os.path.join(self._updater_path, "backup")
-
-		# If clean install is enabled, clear existing files ahead of time
-		# note: will not delete the update.json, update folder, staging, or staging
-		# but will delete all other folders/files in addon directory
-		error = None
-		if clean:
-			try:
-				# implement clearing of all folders/files, except the
-				# updater folder and updater json
-				# Careful, this deletes entire subdirectories recursively...
-				# make sure that base is not a high level shared folder, but
-				# is dedicated just to the addon itself
-				if self._verbose:
-					print("clean=True, clearing addon folder to fresh install state")
-
-				# remove root files and folders (except update folder)
-				files = [f for f in os.listdir(base) if os.path.isfile(os.path.join(base, f))]
-				folders = [f for f in os.listdir(base) if os.path.isdir(os.path.join(base, f))]
-
-				for f in files:
-					os.remove(os.path.join(base, f))
-					print("Clean removing file {}".format(os.path.join(base, f)))
-				for f in folders:
-					if os.path.join(base, f) is self._updater_path:
-						continue
-					shutil.rmtree(os.path.join(base, f))
-					print("Clean removing folder and contents {}".format(os.path.join(base, f)))
-
-			except Exception as err:
-				error = "failed to create clean existing addon folder"
-				print(error, str(err))
-				self.print_trace()
-
-		# Walk through the base addon folder for rules on pre-removing
-		# but avoid removing/altering backup and updater file
-		for path, dirs, files in os.walk(base):
-			# prune ie skip updater folder
-			dirs[:] = [d for d in dirs if os.path.join(path, d) not in [self._updater_path]]
-			for file in files:
-				for pattern in self.remove_pre_update_patterns:
-					if fnmatch.filter([file], pattern):
-						try:
-							fl = os.path.join(path, file)
-							os.remove(fl)
-							if self._verbose:
-								print("Pre-removed file " + file)
-						except OSError:
-							print("Failed to pre-remove " + file)
-							self.print_trace()
-
-		# Walk through the temp addon sub folder for replacements
-		# this implements the overwrite rules, which apply after
-		# the above pre-removal rules. This also performs the
-		# actual file copying/replacements
-		for path, dirs, files in os.walk(merger):
-			# verify this structure works to prune updater sub folder overwriting
-			dirs[:] = [d for d in dirs if os.path.join(path, d) not in [self._updater_path]]
-			rel_path = os.path.relpath(path, merger)
-			dest_path = os.path.join(base, rel_path)
-			if not os.path.exists(dest_path):
-				os.makedirs(dest_path)
-			for file in files:
-				# bring in additional logic around copying/replacing
-				# Blender default: overwrite .py's, don't overwrite the rest
-				dest_file = os.path.join(dest_path, file)
-				srcFile = os.path.join(path, file)
-
-				# decide whether to replace if file already exists, and copy new over
-				if os.path.isfile(dest_file):
-					# otherwise, check each file to see if matches an overwrite pattern
-					replaced = False
-					for pattern in self._overwrite_patterns:
-						if fnmatch.filter([file], pattern):
-							replaced = True
-							break
-					if replaced:
-						os.remove(dest_file)
-						os.rename(srcFile, dest_file)
-						if self._verbose:
-							print("Overwrote file " + os.path.basename(dest_file))
-					else:
-						if self._verbose:
-							print("Pattern not matched to " + os.path.basename(dest_file) + ", not overwritten")
-				else:
-					# file did not previously exist, simply move it over
-					os.rename(srcFile, dest_file)
-					if self._verbose:
-						print("New file " + os.path.basename(dest_file))
-
-		# now remove the temp staging folder and downloaded zip
-		try:
-			shutil.rmtree(staging_path)
-		except:
-			error = "Error: Failed to remove existing staging directory, consider manually removing " + staging_path
-			if self._verbose:
-				print(error)
-			self.print_trace()
-
-	def reload_addon(self):
-		# if post_update false, skip this function
-		# else, unload/reload addon & trigger popup
-		if not self._auto_reload_post_update:
-			print("Restart blender to reload addon and complete update")
-			return
-
-		if self._verbose:
-			print("Reloading addon...")
-		addon_utils.modules(refresh=True)
-		bpy.utils.refresh_script_paths()
-
-		# not allowed in restricted context, such as register module
-		# toggle to refresh
-		if "addon_disable" in dir(bpy.ops.wm):  # 2.7
-			bpy.ops.wm.addon_disable(module=self._addon_package)
-			bpy.ops.wm.addon_refresh()
-			bpy.ops.wm.addon_enable(module=self._addon_package)
-			print("2.7 reload complete")
-		else:  # 2.8
-			bpy.ops.preferences.addon_disable(module=self._addon_package)
-			bpy.ops.preferences.addon_refresh()
-			bpy.ops.preferences.addon_enable(module=self._addon_package)
-			print("2.8 reload complete")
-
-	# -------------------------------------------------------------------------
-	# Other non-api functions and setups
-	# -------------------------------------------------------------------------
-	def clear_state(self):
-		self._update_ready = None
-		self._update_link = None
-		self._update_version = None
-		self._source_zip = None
-		self._error = None
-		self._error_msg = None
-
-	# custom urlretrieve implementation
-	def url_retrieve(self, url_file, filepath):
-		chunk = 1024 * 8
-		f = open(filepath, "wb")
-		while 1:
-			data = url_file.read(chunk)
-			if not data:
-				# print("done.")
-				break
-			f.write(data)
-			# print("Read %s bytes" % len(data))
-		f.close()
-
-	def version_tuple_from_text(self, text):
-		if text is None:
-			return ()
-
-		# should go through string and remove all non-integers,
-		# and for any given break split into a different section
-		segments = list()
-		tmp = ''
-		for char in str(text):
-			if not char.isdigit():
-				if len(tmp) > 0:
-					segments.append(int(tmp))
-					tmp = ''
-			else:
-				tmp += char
-		if len(tmp) > 0:
-			segments.append(int(tmp))
-
-		if len(segments) == 0:
-			if self._verbose:
-				print("No version strings found text: ", text)
-			if not self._include_branches:
-				return ()
-			else:
-				return (text)
-		return tuple(segments)
-
-	# called for running check in a background thread
-	def check_for_update_async(self, callback=None):
-
-		if self._json is not None and "update_ready" in self._json and self._json["version_text"] is not dict():
-			if self._json["update_ready"]:
-				self._update_ready = True
-				self._update_link = self._json["version_text"]["link"]
-				self._update_version = str(self._json["version_text"]["version"])
-				# cached update
-				callback(True)
-				return
-
-		# do the check
-		if not self._check_interval_enable:
-			return
-		elif self._async_checking:
-			if self._verbose:
-				print("Skipping async check, already started")
-			return  # already running the bg thread
-		elif self._update_ready is None:
-			self.start_async_check_update(False, callback)
-
-	def check_for_update_now(self, callback=None):
-
-		self._error = None
-		self._error_msg = None
-
-		if self._verbose:
-			print("Check update pressed, first getting current status")
-		if self._async_checking:
-			if self._verbose:
-				print("Skipping async check, already started")
-			return  # already running the bg thread
-		elif self._update_ready is None:
-			self.start_async_check_update(True, callback)
-		else:
-			self._update_ready = None
-			self.start_async_check_update(True, callback)
-
-	# this function is not async, will always return in sequential fashion
-	# but should have a parent which calls it in another thread
-	def check_for_update(self, now=False):
-		if self._verbose:
-			print("Checking for update function")
-
-		# clear the errors if any
-		self._error = None
-		self._error_msg = None
-
-		# avoid running again in, just return past result if found
-		# but if force now check, then still do it
-		if self._update_ready is not None and not now:
-			return (self._update_ready, self._update_version, self._update_link)
-
-		if self._current_version is None:
-			raise ValueError("current_version not yet defined")
-
-		if self._repo is None:
-			raise ValueError("repo not yet defined")
-
-		if self._user is None:
-			raise ValueError("username not yet defined")
-
-		self.set_updater_json()  # self._json
-
-		if not now and not self.past_interval_timestamp():
-			if self._verbose:
-				print("Aborting check for updated, check interval not reached")
-			return (False, None, None)
-
-		# check if using tags or releases
-		# note that if called the first time, this will pull tags from online
-		if self._fake_install:
-			if self._verbose:
-				print("fake_install = True, setting fake version as ready")
-			self._update_ready = True
-			self._update_version = "(999,999,999)"
-			self._update_link = "http://127.0.0.1"
-
-			return (self._update_ready, self._update_version, self._update_link)
-
-		# primary internet call
-		self.get_tags()  # sets self._tags and self._tag_latest
-
-		self._json["last_check"] = str(datetime.now())
-		self.save_updater_json()
-
-		# can be () or ('master') in addition to branches, and version tag
-		new_version = self.version_tuple_from_text(self.tag_latest)
-
-		if len(self._tags) == 0:
-			self._update_ready = False
-			self._update_version = None
-			self._update_link = None
-			return (False, None, None)
-
-		if not self._include_branches:
-			link = self.select_link(self, self._tags[0])
-		else:
-			n = len(self._include_branch_list)
-			if len(self._tags) == n:
-				# effectively means no tags found on repo
-				# so provide the first one as default
-				link = self.select_link(self, self._tags[0])
-			else:
-				link = self.select_link(self, self._tags[n])
-
-		if new_version == ():
-			self._update_ready = False
-			self._update_version = None
-			self._update_link = None
-			return (False, None, None)
-		elif str(new_version).lower() in self._include_branch_list:
-			# handle situation where master/whichever branch is included
-			# however, this code effectively is not triggered now
-			# as new_version will only be tag names, not branch names
-			if not self._include_branch_auto_check:
-				# don't offer update as ready,
-				# but set the link for the default
-				# branch for installing
-				self._update_ready = False
-				self._update_version = new_version
-				self._update_link = link
-				self.save_updater_json()
-				return (True, new_version, link)
-			else:
-				raise ValueError("include_branch_autocheck: NOT YET DEVELOPED")
-				# bypass releases and look at timestamp of last update
-				# from a branch compared to now, see if commit values
-				# match or not.
-
-		else:
-			# situation where branches not included
-
-			if new_version > self._current_version:
-
-				self._update_ready = True
-				self._update_version = new_version
-				self._update_link = link
-				self.save_updater_json()
-				return (True, new_version, link)
-
-		# elif new_version != self._current_version:
-		# 	self._update_ready = False
-		# 	self._update_version = new_version
-		# 	self._update_link = link
-		# 	self.save_updater_json()
-		# 	return (True, new_version, link)
-
-		# if no update, set ready to False from None
-		self._update_ready = False
-		self._update_version = None
-		self._update_link = None
-		return (False, None, None)
-
-	def set_tag(self, name):
-		"""Assign the tag name and url to update to"""
-		tg = None
-		for tag in self._tags:
-			if name == tag["name"]:
-				tg = tag
-				break
-		if tg:
-			new_version = self.version_tuple_from_text(self.tag_latest)
-			self._update_version = new_version
-			self._update_link = self.select_link(self, tg)
-		elif self._include_branches and name in self._include_branch_list:
-			# scenario if reverting to a specific branch name instead of tag
-			tg = name
-			link = self.form_branch_url(tg)
-			self._update_version = name  # this will break things
-			self._update_link = link
-		if not tg:
-			raise ValueError("Version tag not found: "+name)
-
-	def run_update(self, force=False, revert_tag=None, clean=False, callback=None):
-		"""Runs an install, update, or reversion of an addon from online source
-
-		Arguments:
-			force: Install assigned link, even if self.update_ready is False
-			revert_tag: Version to install, if none uses detected update link
-			clean: not used, but in future could use to totally refresh addon
-			callback: used to run function on update completion
-		"""
-		self._json["update_ready"] = False
-		self._json["ignore"] = False  # clear ignore flag
-		self._json["version_text"] = dict()
-
-		if revert_tag is not None:
-			self.set_tag(revert_tag)
-			self._update_ready = True
-
-		# clear the errors if any
-		self._error = None
-		self._error_msg = None
-
-		if self._verbose:
-			print("Running update")
-
-		if self._fake_install:
-			# change to True, to trigger the reload/"update installed" handler
-			if self._verbose:
-				print("fake_install=True")
-				print("Just reloading and running any handler triggers")
-			self._json["just_updated"] = True
-			self.save_updater_json()
-			if self._backup_current is True:
-				self.create_backup()
-			self.reload_addon()
-			self._update_ready = False
-			res = True  # fake "success" zip download flag
-
-		elif not force:
-			if not self._update_ready:
-				if self._verbose:
-					print("Update stopped, new version not ready")
-				if callback:
-					callback(
-						self._addon_package,
-						"Update stopped, new version not ready")
-				return "Update stopped, new version not ready"
-			elif self._update_link is None:
-				# this shouldn't happen if update is ready
-				if self._verbose:
-					print("Update stopped, update link unavailable")
-				if callback:
-					callback(self._addon_package,
-						"Update stopped, update link unavailable")
-				return "Update stopped, update link unavailable"
-
-			if self._verbose and revert_tag is None:
-				print("Staging update")
-			elif self._verbose:
-				print("Staging install")
-
-			res = self.stage_repository(self._update_link)
-			if not res:
-				print("Error in staging repository: " + str(res))
-				if callback is not None:
-					callback(self._addon_package, self._error_msg)
-				return self._error_msg
-			res = self.unpack_staged_zip(clean)
-			if res < 0:
-				if callback:
-					callback(self._addon_package, self._error_msg)
-				return res
-
-		else:
-			if self._update_link is None:
-				if self._verbose:
-					print("Update stopped, could not get link")
-				return "Update stopped, could not get link"
-			if self._verbose:
-				print("Forcing update")
-
-			res = self.stage_repository(self._update_link)
-			if not res:
-				print("Error in staging repository: " + str(res))
-				if callback:
-					callback(self._addon_package, self._error_msg)
-				return self._error_msg
-			res = self.unpack_staged_zip(clean)
-			if res < 0:
-				return res
-			# would need to compare against other versions held in tags
-
-		# run the front-end's callback if provided
-		if callback:
-			callback(self._addon_package)
-
-		# return something meaningful, 0 means it worked
-		return 0
-
-	def past_interval_timestamp(self):
-		if not self._check_interval_enable:
-			return True  # ie this exact feature is disabled
-
-		if "last_check" not in self._json or self._json["last_check"] == "":
-			return True
-
-		now = datetime.now()
-		last_check = datetime.strptime(self._json["last_check"],
-									"%Y-%m-%d %H:%M:%S.%f")
-		next_check = last_check
-		offset = timedelta(
-			days=self._check_interval_days + 30 * self._check_interval_months,
-			hours=self._check_interval_hours,
-			minutes=self._check_interval_minutes
-			)
-
-		delta = (now - offset) - last_check
-		if delta.total_seconds() > 0:
-			if self._verbose:
-				print("{} Updater: Time to check for updates!".format(self._addon))
-			return True
-
-		if self._verbose:
-			print("{} Updater: Determined it's not yet time to check for updates".format(self._addon))
-		return False
-
-	def get_json_path(self):
-		"""Returns the full path to the JSON state file used by this updater.
-
-		Will also rename old file paths to addon-specific path if found
-		"""
-		json_path = os.path.join(self._updater_path,
-			"{}_updater_status.json".format(self._addon_package))
-		old_json_path = os.path.join(self._updater_path, "updater_status.json")
-
-		# rename old file if it exists
-		try:
-			os.rename(old_json_path, json_path)
-		except FileNotFoundError:
-			pass
-		except Exception as err:
-			print("Other OS error occurred while trying to rename old JSON")
-			print(err)
-			self.print_trace()
-		return json_path
-
-	def set_updater_json(self):
-		"""Load or initialize JSON dictionary data for updater state"""
-		if self._updater_path is None:
-			raise ValueError("updater_path is not defined")
-		elif not os.path.isdir(self._updater_path):
-			os.makedirs(self._updater_path)
-
-		jpath = self.get_json_path()
-		if os.path.isfile(jpath):
-			with open(jpath) as data_file:
-				self._json = json.load(data_file)
-				if self._verbose:
-					print("{} Updater: Read in JSON settings from file".format(
-						self._addon))
-		else:
-			# set data structure
-			self._json = {
-				"last_check": "",
-				"backup_date": "",
-				"update_ready": False,
-				"ignore": False,
-				"just_restored": False,
-				"just_updated": False,
-				"version_text": dict()
-			}
-			self.save_updater_json()
-
-	def save_updater_json(self):
-		# first save the state
-		if self._update_ready:
-			if isinstance(self._update_version, tuple):
-				self._json["update_ready"] = True
-				self._json["version_text"]["link"] = self._update_link
-				self._json["version_text"]["version"] = self._update_version
-			else:
-				self._json["update_ready"] = False
-				self._json["version_text"] = dict()
-		else:
-			self._json["update_ready"] = False
-			self._json["version_text"] = dict()
-
-		jpath = self.get_json_path()
-		outf = open(jpath, 'w')
-		data_out = json.dumps(self._json, indent=4)
-		outf.write(data_out)
-		outf.close()
-		if self._verbose:
-			print(self._addon+": Wrote out updater JSON settings to file, with the contents:")
-			print(self._json)
-
-	def json_reset_postupdate(self):
-		self._json["just_updated"] = False
-		self._json["update_ready"] = False
-		self._json["version_text"] = dict()
-		self.save_updater_json()
-
-	def json_reset_restore(self):
-		self._json["just_restored"] = False
-		self._json["update_ready"] = False
-		self._json["version_text"] = dict()
-		self.save_updater_json()
-		self._update_ready = None  # reset so you could check update again
-
-	def ignore_update(self):
-		self._json["ignore"] = True
-		self.save_updater_json()
-
-	# -------------------------------------------------------------------------
-	# ASYNC stuff
-	# -------------------------------------------------------------------------
-	def start_async_check_update(self, now=False, callback=None):
-		"""Start a background thread which will check for updates"""
-		if self._async_checking:
-			return
-		if self._verbose:
-			print("{} updater: Starting background checking thread".format(
-				self._addon))
-		check_thread = threading.Thread(target=self.async_check_update,
-										args=(now, callback,))
-		check_thread.daemon = True
-		self._check_thread = check_thread
-		check_thread.start()
-
-	def async_check_update(self, now, callback=None):
-		"""Perform update check, run as target of background thread"""
-		self._async_checking = True
-		if self._verbose:
-			print("{} BG thread: Checking for update now in background".format(
-				self._addon))
-
-		try:
-			self.check_for_update(now=now)
-		except Exception as exception:
-			print("Checking for update error:")
-			print(exception)
-			self.print_trace()
-			if not self._error:
-				self._update_ready = False
-				self._update_version = None
-				self._update_link = None
-				self._error = "Error occurred"
-				self._error_msg = "Encountered an error while checking for updates"
-
-		self._async_checking = False
-		self._check_thread = None
-
-		if self._verbose:
-			print("{} BG thread: Finished checking for update, doing callback".format(self._addon))
-		if callback:
-			callback(self._update_ready)
-
-	def stop_async_check_update(self):
-		"""Method to give impression of stopping check for update.
-
-		Currently does nothing but allows user to retry/stop blocking UI from
-		hitting a refresh button. This does not actually stop the thread, as it
-		will complete after the connection timeout regardless. If the thread
-		does complete with a successful response, this will be still displayed
-		on next UI refresh (ie no update, or update available).
-		"""
-		if self._check_thread is not None:
-			if self._verbose:
-				print("Thread will end in normal course.")
-			# however, "There is no direct kill method on a thread object."
-			# better to let it run its course
-			# self._check_thread.stop()
-		self._async_checking = False
-		self._error = None
-		self._error_msg = None
+    """
+    This is the singleton class to reference a copy from,
+    it is the shared module level class
+    """
+    def __init__(self):
+
+        self._engine = GithubEngine()
+        self._user = None
+        self._repo = None
+        self._website = None
+        self._current_version = None
+        self._subfolder_path = None
+        self._tags = list()
+        self._tag_latest = None
+        self._tag_names = list()
+        self._latest_release = None
+        self._use_releases = False
+        self._include_branches = False
+        self._include_branch_list = ['master']
+        self._include_branch_auto_check = False
+        self._manual_only = False
+        self._version_min_update = None
+        self._version_max_update = None
+
+        # by default, backup current addon if new is being loaded
+        self._backup_current = True
+        self._backup_ignore_patterns = None
+
+        # set patterns for what files to overwrite on update
+        self._overwrite_patterns = ["*.py", "*.pyc"]
+        self._remove_pre_update_patterns = list()
+
+        # by default, don't auto enable/disable the addon on update
+        # as it is slightly less stable/won't always fully reload module
+        self._auto_reload_post_update = False
+
+        # settings relating to frequency and whether to enable auto background check
+        self._check_interval_enable = False
+        self._check_interval_months = 0
+        self._check_interval_days = 7
+        self._check_interval_hours = 0
+        self._check_interval_minutes = 0
+
+        # runtime variables, initial conditions
+        self._verbose = False
+        self._use_print_traces = True
+        self._fake_install = False
+        self._async_checking = False  # only true when async daemon started
+        self._update_ready = None
+        self._update_link = None
+        self._update_version = None
+        self._source_zip = None
+        self._check_thread = None
+        self._select_link = None
+        self.skip_tag = None
+
+        # get from module data
+        self._addon = __package__.lower()
+        self._addon_package = __package__  # must not change
+        self._updater_path = os.path.join(os.path.dirname(__file__), self._addon + "_updater")
+        self._addon_root = os.path.dirname(__file__)
+        self._json = dict()
+        self._error = None
+        self._error_msg = None
+        self._prefiltered_tag_count = 0
+
+        # UI code only, ie not used within this module but still useful
+        # properties to have
+
+        # to verify a valid import, in place of placeholder import
+        self.show_popups = True  # used in UI to show or not show update popups
+        self.invalid_updater = False
+
+        # pre-assign basic select-link function
+        def select_link_function(self, tag):
+            return tag["zipball_url"]
+
+        self._select_link = select_link_function
+
+    def print_trace(self):
+        """Print handled exception details when use_print_traces is set"""
+        if self._use_print_traces:
+            traceback.print_exc()
+
+    # -------------------------------------------------------------------------
+    # Getters and setters
+    # -------------------------------------------------------------------------
+    @property
+    def addon(self):
+        return self._addon
+
+    @addon.setter
+    def addon(self, value):
+        self._addon = str(value)
+
+    @property
+    def api_url(self):
+        return self._engine.api_url
+
+    @api_url.setter
+    def api_url(self, value):
+        if not self.check_is_url(value):
+            raise ValueError("Not a valid URL: " + value)
+        self._engine.api_url = value
+
+    @property
+    def async_checking(self):
+        return self._async_checking
+
+    @property
+    def auto_reload_post_update(self):
+        return self._auto_reload_post_update
+
+    @auto_reload_post_update.setter
+    def auto_reload_post_update(self, value):
+        try:
+            self._auto_reload_post_update = bool(value)
+        except:
+            raise ValueError("auto_reload_post_update must be a boolean value")
+
+    @property
+    def backup_current(self):
+        return self._backup_current
+
+    @backup_current.setter
+    def backup_current(self, value):
+        if value is None:
+            self._backup_current = False
+            return
+        else:
+            self._backup_current = value
+
+    @property
+    def backup_ignore_patterns(self):
+        return self._backup_ignore_patterns
+
+    @backup_ignore_patterns.setter
+    def backup_ignore_patterns(self, value):
+        if value is None:
+            self._backup_ignore_patterns = None
+            return
+        elif not isinstance(value, list):
+            raise ValueError("Backup pattern must be in list format")
+        else:
+            self._backup_ignore_patterns = value
+
+    @property
+    def check_interval(self):
+        return (self._check_interval_enable,
+                self._check_interval_months,
+                self._check_interval_days,
+                self._check_interval_hours,
+                self._check_interval_minutes)
+
+    @property
+    def current_version(self):
+        return self._current_version
+
+    @current_version.setter
+    def current_version(self, tuple_values):
+        if tuple_values is None:
+            self._current_version = None
+            return
+        elif type(tuple_values) is not tuple:
+            try:
+                tuple(tuple_values)
+            except:
+                raise ValueError(
+                    "Not a tuple! current_version must be a tuple of integers")
+        for i in tuple_values:
+            if type(i) is not int:
+                raise ValueError(
+                    "Not an integer! current_version must be a tuple of integers")
+        self._current_version = tuple(tuple_values)
+
+    @property
+    def engine(self):
+        return self._engine.name
+
+    @engine.setter
+    def engine(self, value):
+        if value.lower() is "github":
+            self._engine = GithubEngine()
+        elif value.lower() is "gitlab":
+            self._engine = GitlabEngine()
+        elif value.lower() is "bitbucket":
+            self._engine = BitbucketEngine()
+        else:
+            raise ValueError("Invalid engine selection")
+
+    @property
+    def error(self):
+        return self._error
+
+    @property
+    def error_msg(self):
+        return self._error_msg
+
+    @property
+    def fake_install(self):
+        return self._fake_install
+
+    @fake_install.setter
+    def fake_install(self, value):
+        if not isinstance(value, bool):
+            raise ValueError("fake_install must be a boolean value")
+        self._fake_install = bool(value)
+
+    # not currently used
+    @property
+    def include_branch_auto_check(self):
+        return self._include_branch_auto_check
+
+    @include_branch_auto_check.setter
+    def include_branch_auto_check(self, value):
+        try:
+            self._include_branch_auto_check = bool(value)
+        except:
+            raise ValueError("include_branch_autocheck must be a boolean value")
+
+    @property
+    def include_branch_list(self):
+        return self._include_branch_list
+
+    @include_branch_list.setter
+    def include_branch_list(self, value):
+        try:
+            if value is None:
+                self._include_branch_list = ['master']
+            elif not isinstance(value, list) or len(value) == 0:
+                raise ValueError("include_branch_list should be a list of valid branches")
+            else:
+                self._include_branch_list = value
+        except:
+            raise ValueError("include_branch_list should be a list of valid branches")
+
+    @property
+    def include_branches(self):
+        return self._include_branches
+
+    @include_branches.setter
+    def include_branches(self, value):
+        try:
+            self._include_branches = bool(value)
+        except:
+            raise ValueError("include_branches must be a boolean value")
+
+    @property
+    def json(self):
+        if len(self._json) == 0:
+            self.set_updater_json()
+        return self._json
+
+    @property
+    def latest_release(self):
+        if self._latest_release is None:
+            return None
+        return self._latest_release
+
+    @property
+    def manual_only(self):
+        return self._manual_only
+
+    @manual_only.setter
+    def manual_only(self, value):
+        try:
+            self._manual_only = bool(value)
+        except:
+            raise ValueError("manual_only must be a boolean value")
+
+    @property
+    def overwrite_patterns(self):
+        return self._overwrite_patterns
+
+    @overwrite_patterns.setter
+    def overwrite_patterns(self, value):
+        if value is None:
+            self._overwrite_patterns = ["*.py", "*.pyc"]
+        elif not isinstance(value, list):
+            raise ValueError("overwrite_patterns needs to be in a list format")
+        else:
+            self._overwrite_patterns = value
+
+    @property
+    def private_token(self):
+        return self._engine.token
+
+    @private_token.setter
+    def private_token(self, value):
+        if value is None:
+            self._engine.token = None
+        else:
+            self._engine.token = str(value)
+
+    @property
+    def remove_pre_update_patterns(self):
+        return self._remove_pre_update_patterns
+
+    @remove_pre_update_patterns.setter
+    def remove_pre_update_patterns(self, value):
+        if value is None:
+            self._remove_pre_update_patterns = list()
+        elif not isinstance(value, list):
+            raise ValueError("remove_pre_update_patterns needs to be in a list format")
+        else:
+            self._remove_pre_update_patterns = value
+
+    @property
+    def repo(self):
+        return self._repo
+
+    @repo.setter
+    def repo(self, value):
+        try:
+            self._repo = str(value)
+        except:
+            raise ValueError("repo must be a string value")
+
+    @property
+    def select_link(self):
+        return self._select_link
+
+    @select_link.setter
+    def select_link(self, value):
+        # ensure it is a function assignment, with signature:
+        # input self, tag; returns link name
+        if not hasattr(value, "__call__"):
+            raise ValueError("select_link must be a function")
+        self._select_link = value
+
+    @property
+    def stage_path(self):
+        return self._updater_path
+
+    @stage_path.setter
+    def stage_path(self, value):
+        if value is None:
+            if self._verbose:
+                print("Aborting assigning stage_path, it's null")
+            return
+        elif value is not None and not os.path.exists(value):
+            try:
+                os.makedirs(value)
+            except:
+                if self._verbose:
+                    print("Error trying to staging path")
+                self.print_trace()
+                return
+        self._updater_path = value
+
+    @property
+    def subfolder_path(self):
+        return self._subfolder_path
+
+    @subfolder_path.setter
+    def subfolder_path(self, value):
+        self._subfolder_path = value
+
+    @property
+    def tags(self):
+        if len(self._tags) == 0:
+            return list()
+        tag_names = list()
+        for tag in self._tags:
+            tag_names.append(tag["name"])
+        return tag_names
+
+    @property
+    def tag_latest(self):
+        if self._tag_latest is None:
+            return None
+        return self._tag_latest["name"]
+
+    @property
+    def update_link(self):
+        return self._update_link
+
+    @property
+    def update_ready(self):
+        return self._update_ready
+
+    @property
+    def update_version(self):
+        return self._update_version
+
+    @property
+    def use_releases(self):
+        return self._use_releases
+
+    @use_releases.setter
+    def use_releases(self, value):
+        try:
+            self._use_releases = bool(value)
+        except:
+            raise ValueError("use_releases must be a boolean value")
+
+    @property
+    def user(self):
+        return self._user
+
+    @user.setter
+    def user(self, value):
+        try:
+            self._user = str(value)
+        except:
+            raise ValueError("User must be a string value")
+
+    @property
+    def verbose(self):
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, value):
+        try:
+            self._verbose = bool(value)
+            if self._verbose:
+                print(self._addon + " updater verbose is enabled")
+        except:
+            raise ValueError("Verbose must be a boolean value")
+
+    @property
+    def use_print_traces(self):
+        return self._use_print_traces
+
+    @use_print_traces.setter
+    def use_print_traces(self, value):
+        try:
+            self._use_print_traces = bool(value)
+        except:
+            raise ValueError("use_print_traces must be a boolean value")
+
+    @property
+    def version_max_update(self):
+        return self._version_max_update
+
+    @version_max_update.setter
+    def version_max_update(self, value):
+        if value is None:
+            self._version_max_update = None
+            return
+        if not isinstance(value, tuple):
+            raise ValueError("Version maximum must be a tuple")
+        for subvalue in value:
+            if type(subvalue) is not int:
+                raise ValueError("Version elements must be integers")
+        self._version_max_update = value
+
+    @property
+    def version_min_update(self):
+        return self._version_min_update
+
+    @version_min_update.setter
+    def version_min_update(self, value):
+        if value is None:
+            self._version_min_update = None
+            return
+        if not isinstance(value, tuple):
+            raise ValueError("Version minimum must be a tuple")
+        for subvalue in value:
+            if type(subvalue) != int:
+                raise ValueError("Version elements must be integers")
+        self._version_min_update = value
+
+    @property
+    def website(self):
+        return self._website
+
+    @website.setter
+    def website(self, value):
+        if not self.check_is_url(value):
+            raise ValueError("Not a valid URL: " + value)
+        self._website = value
+
+    # -------------------------------------------------------------------------
+    # Parameter validation related functions
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def check_is_url(url):
+        if not ("http://" in url or "https://" in url):
+            return False
+        if "." not in url:
+            return False
+        return True
+
+    def _get_tag_names(self):
+        tag_names = list()
+        self.get_tags()
+        for tag in self._tags:
+            tag_names.append(tag["name"])
+        return tag_names
+
+    def set_check_interval(self, enabled=False, months=0, days=14, hours=0, minutes=0):
+        # enabled = False, default initially will not check against frequency
+        # if enabled, default is then 2 weeks
+
+        if type(enabled) is not bool:
+            raise ValueError("Enable must be a boolean value")
+        if type(months) is not int:
+            raise ValueError("Months must be an integer value")
+        if type(days) is not int:
+            raise ValueError("Days must be an integer value")
+        if type(hours) is not int:
+            raise ValueError("Hours must be an integer value")
+        if type(minutes) is not int:
+            raise ValueError("Minutes must be an integer value")
+
+        if not enabled:
+            self._check_interval_enable = False
+        else:
+            self._check_interval_enable = True
+
+        self._check_interval_months = months
+        self._check_interval_days = days
+        self._check_interval_hours = hours
+        self._check_interval_minutes = minutes
+
+    # declare how the class gets printed
+
+    def __repr__(self):
+        return "<Module updater from {a}>".format(a=__file__)
+
+    def __str__(self):
+        return "Updater, with user: {a}, repository: {b}, url: {c}".format(
+                        a=self._user,
+                        b=self._repo, c=self.form_repo_url())
+
+    # -------------------------------------------------------------------------
+    # API-related functions
+    # -------------------------------------------------------------------------
+    def form_repo_url(self):
+        return self._engine.form_repo_url(self)
+
+    def form_tags_url(self):
+        return self._engine.form_tags_url(self)
+
+    def form_branch_url(self, branch):
+        return self._engine.form_branch_url(branch, self)
+
+    def get_tags(self):
+        request = self.form_tags_url()
+        if self._verbose:
+            print("Getting tags from server")
+
+        # get all tags, internet call
+        all_tags = self._engine.parse_tags(self.get_api(request), self)
+        if all_tags is not None:
+            self._prefiltered_tag_count = len(all_tags)
+        else:
+            self._prefiltered_tag_count = 0
+            all_tags = list()
+
+        # pre-process to skip tags
+        if self.skip_tag is not None:
+            self._tags = [tg for tg in all_tags if not self.skip_tag(self, tg)]
+        else:
+            self._tags = all_tags
+
+        # get additional branches too, if needed, and place in front
+        # Does NO checking here whether branch is valid
+        if self._include_branches:
+            temp_branches = self._include_branch_list.copy()
+            temp_branches.reverse()
+            for branch in temp_branches:
+                request = self.form_branch_url(branch)
+                include = {
+                    "name": branch.title(),
+                    "zipball_url": request
+                }
+                self._tags = [include] + self._tags  # append to front
+
+        if self._tags is None:
+            # some error occurred
+            self._tag_latest = None
+            self._tags = list()
+            return
+        elif self._prefiltered_tag_count == 0 and not self._include_branches:
+            self._tag_latest = None
+            if self._error is None:  # if not None, could have had no internet
+                self._error = "No releases found"
+                self._error_msg = "No releases or tags found on this repository"
+            if self._verbose:
+                print("No releases or tags found on this repository")
+        elif self._prefiltered_tag_count == 0 and self._include_branches:
+            if not self._error:
+                self._tag_latest = self._tags[0]
+            if self._verbose:
+                branch = self._include_branch_list[0]
+                print("{} branch found, no releases".format(branch), self._tags[0])
+        elif (len(self._tags) - len(self._include_branch_list) == 0 and self._include_branches) \
+                or (len(self._tags) == 0 and not self._include_branches) \
+                and self._prefiltered_tag_count > 0:
+            self._tag_latest = None
+            self._error = "No releases available"
+            self._error_msg = "No versions found within compatible version range"
+            if self._verbose:
+                print("No versions found within compatible version range")
+        else:
+            if not self._include_branches:
+                self._tag_latest = self._tags[0]
+                if self._verbose:
+                    print("Most recent tag found:", self._tags[0]['name'])
+            else:
+                # don't return branch if in list
+                n = len(self._include_branch_list)
+                self._tag_latest = self._tags[n]  # guaranteed at least len()=n+1
+                if self._verbose:
+                    print("Most recent tag found:", self._tags[n]['name'])
+
+    # all API calls to base url
+    def get_raw(self, url):
+        # print("Raw request:", url)
+        request = urllib.request.Request(url)
+        try:
+            context = ssl._create_unverified_context()
+        except:
+            # some blender packaged python versions don't have this, largely
+            # useful for local network setups otherwise minimal impact
+            context = None
+
+        # setup private request headers if appropriate
+        if self._engine.token is not None:
+            if self._engine.name == "gitlab":
+                request.add_header('PRIVATE-TOKEN', self._engine.token)
+            else:
+                if self._verbose:
+                    print("Tokens not setup for engine yet")
+
+        # Always set user agent
+        request.add_header('User-Agent', "Python/" + str(platform.python_version()))
+
+        # run the request
+        try:
+            if context:
+                result = urllib.request.urlopen(request, context=context)
+            else:
+                result = urllib.request.urlopen(request)
+        except urllib.error.HTTPError as e:
+            if str(e.code) == "403":
+                self._error = "HTTP error (access denied)"
+                self._error_msg = str(e.code) + " - server error response"
+                print(self._error, self._error_msg)
+            else:
+                self._error = "HTTP error"
+                self._error_msg = str(e.code)
+                print(self._error, self._error_msg)
+            self.print_trace()
+            self._update_ready = None
+        except urllib.error.URLError as e:
+            reason = str(e.reason)
+            if "TLSV1_ALERT" in reason or "SSL" in reason.upper():
+                self._error = "Connection rejected, download manually"
+                self._error_msg = reason
+                print(self._error, self._error_msg)
+            else:
+                self._error = "URL error, check internet connection"
+                self._error_msg = reason
+                print(self._error, self._error_msg)
+            self.print_trace()
+            self._update_ready = None
+            return None
+        else:
+            result_string = result.read()
+            result.close()
+            return result_string.decode()
+
+    # result of all api calls, decoded into json format
+    def get_api(self, url):
+        # return the json version
+        get = None
+        get = self.get_raw(url)
+        if get is not None:
+            try:
+                return json.JSONDecoder().decode(get)
+            except Exception as e:
+                self._error = "API response has invalid JSON format"
+                self._error_msg = str(e.reason)
+                self._update_ready = None
+                print(self._error, self._error_msg)
+                self.print_trace()
+                return None
+        else:
+            return None
+
+    # create a working directory and download the new files
+    def stage_repository(self, url):
+
+        local = os.path.join(self._updater_path, "update_staging")
+        error = None
+
+        # make/clear the staging folder
+        # ensure the folder is always "clean"
+        if self._verbose:
+            print("Preparing staging folder for download:\n", local)
+        if os.path.isdir(local):
+            try:
+                shutil.rmtree(local)
+                os.makedirs(local)
+            except:
+                error = "failed to remove existing staging directory"
+                self.print_trace()
+        else:
+            try:
+                os.makedirs(local)
+            except:
+                error = "failed to create staging directory"
+                self.print_trace()
+
+        if error is not None:
+            if self._verbose:
+                print("Error: Aborting update, " + error)
+            self._error = "Update aborted, staging path error"
+            self._error_msg = "Error: {}".format(error)
+            return False
+
+        if self._backup_current:
+            self.create_backup()
+
+        if self._verbose:
+            print("Now retrieving the new source zip")
+
+        self._source_zip = os.path.join(local, "source.zip")
+
+        if self._verbose:
+            print("Starting download update zip")
+        try:
+            request = urllib.request.Request(url)
+            context = ssl._create_unverified_context()
+
+            # setup private token if appropriate
+            if self._engine.token is not None:
+                if self._engine.name == "gitlab":
+                    request.add_header('PRIVATE-TOKEN', self._engine.token)
+                else:
+                    if self._verbose:
+                        print("Tokens not setup for selected engine yet")
+
+            # Always set user agent
+            request.add_header('User-Agent', "Python/" + str(platform.python_version()))
+
+            self.url_retrieve(urllib.request.urlopen(request, context=context), self._source_zip)
+            # add additional checks on file size being non-zero
+            if self._verbose:
+                print("Successfully downloaded update zip")
+            return True
+        except Exception as e:
+            self._error = "Error retrieving download, bad link?"
+            self._error_msg = "Error: {}".format(e)
+            if self._verbose:
+                print("Error retrieving download, bad link?")
+                print("Error: {}".format(e))
+            self.print_trace()
+            return False
+
+    def create_backup(self):
+        if self._verbose:
+            print("Backing up current addon folder")
+        local = os.path.join(self._updater_path, "backup")
+        tempdest = os.path.join(self._addon_root, os.pardir,
+                                self._addon + "_updater_backup_temp")
+
+        if self._verbose:
+            print("Backup destination path: ", local)
+
+        if os.path.isdir(local):
+            try:
+                shutil.rmtree(local)
+            except:
+                if self._verbose:
+                    print("Failed to removed previous backup folder, continuing")
+                self.print_trace()
+
+        # remove the temp folder; shouldn't exist but could if previously interrupted
+        if os.path.isdir(tempdest):
+            try:
+                shutil.rmtree(tempdest)
+            except:
+                if self._verbose:
+                    print("Failed to remove existing temp folder, continuing")
+                self.print_trace()
+
+        # make the full addon copy, which temporarily places outside the addon folder
+        if self._backup_ignore_patterns is not None:
+            shutil.copytree(
+                self._addon_root, tempdest,
+                ignore=shutil.ignore_patterns(*self._backup_ignore_patterns))
+        else:
+            shutil.copytree(self._addon_root, tempdest)
+        shutil.move(tempdest, local)
+
+        # save the date for future ref
+        now = datetime.now()
+        self._json["backup_date"] = "{m}-{d}-{yr}".format(
+                m=now.strftime("%B"), d=now.day, yr=now.year)
+        self.save_updater_json()
+
+    def restore_backup(self):
+        if self._verbose:
+            print("Restoring backup")
+
+        if self._verbose:
+            print("Backing up current addon folder")
+        backuploc = os.path.join(self._updater_path, "backup")
+        tempdest = os.path.join(self._addon_root, os.pardir,
+                        self._addon + "_updater_backup_temp")
+        tempdest = os.path.abspath(tempdest)
+
+        # make the copy
+        shutil.move(backuploc, tempdest)
+        shutil.rmtree(self._addon_root)
+        os.rename(tempdest, self._addon_root)
+
+        self._json["backup_date"] = ""
+        self._json["just_restored"] = True
+        self._json["just_updated"] = True
+        self.save_updater_json()
+
+        self.reload_addon()
+
+    def unpack_staged_zip(self, clean=False):
+        """Unzip the downloaded file, and validate contents"""
+        if not os.path.isfile(self._source_zip):
+            if self._verbose:
+                print("Error, update zip not found")
+            self._error = "Install failed"
+            self._error_msg = "Downloaded zip not found"
+            return -1
+
+        # clear the existing source folder in case previous files remain
+        outdir = os.path.join(self._updater_path, "source")
+        try:
+            shutil.rmtree(outdir)
+            if self._verbose:
+                print("Source folder cleared")
+        except:
+            self.print_trace()
+
+        # Create parent directories if needed, would not be relevant unless
+        # installing addon into another location or via an addon manager
+        try:
+            os.mkdir(outdir)
+        except Exception as err:
+            print("Error occurred while making extract dir:")
+            print(str(err))
+            self.print_trace()
+            self._error = "Install failed"
+            self._error_msg = "Failed to make extract directory"
+            return -1
+
+        if not os.path.isdir(outdir):
+            print("Failed to create source directory")
+            self._error = "Install failed"
+            self._error_msg = "Failed to create extract directory"
+            return -1
+
+        if self._verbose:
+            print("Begin extracting source from zip:", self._source_zip)
+        zfile = zipfile.ZipFile(self._source_zip, "r")
+
+        if not zfile:
+            if self._verbose:
+                print("Resulting file is not a zip, cannot extract")
+            self._error = "Install failed"
+            self._error_msg = "Resulting file is not a zip, cannot extract"
+            return -1
+
+        # Now extract directly from the first subfolder (not root)
+        # this avoids adding the first subfolder to the path length,
+        # which can be too long if the download has the SHA in the name
+        zsep = '/'  # os.sep  # might just always be / even on windows
+        for name in zfile.namelist():
+            if zsep not in name:
+                continue
+            top_folder = name[:name.index(zsep) + 1]
+            if name == top_folder + zsep:
+                continue  # skip top level folder
+            sub_path = name[name.index(zsep) + 1:]
+            if name.endswith(zsep):
+                try:
+                    os.mkdir(os.path.join(outdir, sub_path))
+                    if self._verbose:
+                        print("Extract - mkdir: ", os.path.join(outdir, sub_path))
+                except OSError as exc:
+                    if exc.errno != errno.EEXIST:
+                        self._error = "Install failed"
+                        self._error_msg = "Could not create folder from zip"
+                        self.print_trace()
+                        return -1
+            else:
+                with open(os.path.join(outdir, sub_path), "wb") as outfile:
+                    data = zfile.read(name)
+                    outfile.write(data)
+                    if self._verbose:
+                        print("Extract - create:", os.path.join(outdir, sub_path))
+
+        if self._verbose:
+            print("Extracted source")
+
+        unpath = os.path.join(self._updater_path, "source")
+        if not os.path.isdir(unpath):
+            self._error = "Install failed"
+            self._error_msg = "Extracted path does not exist"
+            print("Extracted path does not exist: ", unpath)
+            return -1
+
+        if self._subfolder_path:
+            self._subfolder_path.replace('/', os.path.sep)
+            self._subfolder_path.replace('\\', os.path.sep)
+
+        # either directly in root of zip/one subfolder, or use specified path
+        if not os.path.isfile(os.path.join(unpath, "__init__.py")):
+            dirlist = os.listdir(unpath)
+            if len(dirlist) > 0:
+                if self._subfolder_path == "" or self._subfolder_path is None:
+                    unpath = os.path.join(unpath, dirlist[0])
+                else:
+                    unpath = os.path.join(unpath, self._subfolder_path)
+
+            # smarter check for additional sub folders for a single folder
+            # containing __init__.py
+            if not os.path.isfile(os.path.join(unpath, "__init__.py")):
+                if self._verbose:
+                    print("not a valid addon found")
+                    print("Paths:")
+                    print(dirlist)
+                self._error = "Install failed"
+                self._error_msg = "No __init__ file found in new source"
+                return -1
+
+        # merge code with running addon directory, using blender default behavior
+        # plus any modifiers indicated by user (e.g. force remove/keep)
+        self.deep_merge_directory(self._addon_root, unpath, clean)
+
+        # Now save the json state
+        #  Change to True, to trigger the handler on other side
+        #  if allowing reloading within same blender instance
+        self._json["just_updated"] = True
+        self.save_updater_json()
+        self.reload_addon()
+        self._update_ready = False
+        return 0
+
+    def deep_merge_directory(self, base, merger, clean=False):
+        """Merge folder 'merger' into folder 'base' without deleting existing"""
+        if not os.path.exists(base):
+            if self._verbose:
+                print("Base path does not exist:", base)
+            return -1
+        elif not os.path.exists(merger):
+            if self._verbose:
+                print("Merger path does not exist")
+            return -1
+
+        # paths to be aware of and not overwrite/remove/etc
+        staging_path = os.path.join(self._updater_path, "update_staging")
+        backup_path = os.path.join(self._updater_path, "backup")
+
+        # If clean install is enabled, clear existing files ahead of time
+        # note: will not delete the update.json, update folder, staging, or staging
+        # but will delete all other folders/files in addon directory
+        error = None
+        if clean:
+            try:
+                # implement clearing of all folders/files, except the
+                # updater folder and updater json
+                # Careful, this deletes entire subdirectories recursively...
+                # make sure that base is not a high level shared folder, but
+                # is dedicated just to the addon itself
+                if self._verbose:
+                    print("clean=True, clearing addon folder to fresh install state")
+
+                # remove root files and folders (except update folder)
+                files = [f for f in os.listdir(base) if os.path.isfile(os.path.join(base, f))]
+                folders = [f for f in os.listdir(base) if os.path.isdir(os.path.join(base, f))]
+
+                for f in files:
+                    os.remove(os.path.join(base, f))
+                    print("Clean removing file {}".format(os.path.join(base, f)))
+                for f in folders:
+                    if os.path.join(base, f) is self._updater_path:
+                        continue
+                    shutil.rmtree(os.path.join(base, f))
+                    print("Clean removing folder and contents {}".format(os.path.join(base, f)))
+
+            except Exception as err:
+                error = "failed to create clean existing addon folder"
+                print(error, str(err))
+                self.print_trace()
+
+        # Walk through the base addon folder for rules on pre-removing
+        # but avoid removing/altering backup and updater file
+        for path, dirs, files in os.walk(base):
+            # prune ie skip updater folder
+            dirs[:] = [d for d in dirs if os.path.join(path, d) not in [self._updater_path]]
+            for file in files:
+                for pattern in self.remove_pre_update_patterns:
+                    if fnmatch.filter([file], pattern):
+                        try:
+                            fl = os.path.join(path, file)
+                            os.remove(fl)
+                            if self._verbose:
+                                print("Pre-removed file " + file)
+                        except OSError:
+                            print("Failed to pre-remove " + file)
+                            self.print_trace()
+
+        # Walk through the temp addon sub folder for replacements
+        # this implements the overwrite rules, which apply after
+        # the above pre-removal rules. This also performs the
+        # actual file copying/replacements
+        for path, dirs, files in os.walk(merger):
+            # verify this structure works to prune updater sub folder overwriting
+            dirs[:] = [d for d in dirs if os.path.join(path, d) not in [self._updater_path]]
+            rel_path = os.path.relpath(path, merger)
+            dest_path = os.path.join(base, rel_path)
+            if not os.path.exists(dest_path):
+                os.makedirs(dest_path)
+            for file in files:
+                # bring in additional logic around copying/replacing
+                # Blender default: overwrite .py's, don't overwrite the rest
+                dest_file = os.path.join(dest_path, file)
+                srcFile = os.path.join(path, file)
+
+                # decide whether to replace if file already exists, and copy new over
+                if os.path.isfile(dest_file):
+                    # otherwise, check each file to see if matches an overwrite pattern
+                    replaced = False
+                    for pattern in self._overwrite_patterns:
+                        if fnmatch.filter([file], pattern):
+                            replaced = True
+                            break
+                    if replaced:
+                        os.remove(dest_file)
+                        os.rename(srcFile, dest_file)
+                        if self._verbose:
+                            print("Overwrote file " + os.path.basename(dest_file))
+                    else:
+                        if self._verbose:
+                            print("Pattern not matched to " + os.path.basename(dest_file) + ", not overwritten")
+                else:
+                    # file did not previously exist, simply move it over
+                    os.rename(srcFile, dest_file)
+                    if self._verbose:
+                        print("New file " + os.path.basename(dest_file))
+
+        # now remove the temp staging folder and downloaded zip
+        try:
+            shutil.rmtree(staging_path)
+        except:
+            error = "Error: Failed to remove existing staging directory, consider manually removing " + staging_path
+            if self._verbose:
+                print(error)
+            self.print_trace()
+
+    def reload_addon(self):
+        # if post_update false, skip this function
+        # else, unload/reload addon & trigger popup
+        if not self._auto_reload_post_update:
+            print("Restart blender to reload addon and complete update")
+            return
+
+        if self._verbose:
+            print("Reloading addon...")
+        addon_utils.modules(refresh=True)
+        bpy.utils.refresh_script_paths()
+
+        # not allowed in restricted context, such as register module
+        # toggle to refresh
+        if "addon_disable" in dir(bpy.ops.wm):  # 2.7
+            bpy.ops.wm.addon_disable(module=self._addon_package)
+            bpy.ops.wm.addon_refresh()
+            bpy.ops.wm.addon_enable(module=self._addon_package)
+            print("2.7 reload complete")
+        else:  # 2.8
+            bpy.ops.preferences.addon_disable(module=self._addon_package)
+            bpy.ops.preferences.addon_refresh()
+            bpy.ops.preferences.addon_enable(module=self._addon_package)
+            print("2.8 reload complete")
+
+    # -------------------------------------------------------------------------
+    # Other non-api functions and setups
+    # -------------------------------------------------------------------------
+    def clear_state(self):
+        self._update_ready = None
+        self._update_link = None
+        self._update_version = None
+        self._source_zip = None
+        self._error = None
+        self._error_msg = None
+
+    # custom urlretrieve implementation
+    def url_retrieve(self, url_file, filepath):
+        chunk = 1024 * 8
+        f = open(filepath, "wb")
+        while 1:
+            data = url_file.read(chunk)
+            if not data:
+                # print("done.")
+                break
+            f.write(data)
+            # print("Read %s bytes" % len(data))
+        f.close()
+
+    def version_tuple_from_text(self, text):
+        if text is None:
+            return ()
+
+        # should go through string and remove all non-integers,
+        # and for any given break split into a different section
+        segments = list()
+        tmp = ''
+        for char in str(text):
+            if not char.isdigit():
+                if len(tmp) > 0:
+                    segments.append(int(tmp))
+                    tmp = ''
+            else:
+                tmp += char
+        if len(tmp) > 0:
+            segments.append(int(tmp))
+
+        if len(segments) == 0:
+            if self._verbose:
+                print("No version strings found text: ", text)
+            if not self._include_branches:
+                return ()
+            else:
+                return (text)
+        return tuple(segments)
+
+    # called for running check in a background thread
+    def check_for_update_async(self, callback=None):
+
+        if self._json is not None and "update_ready" in self._json and self._json["version_text"] is not dict():
+            if self._json["update_ready"]:
+                self._update_ready = True
+                self._update_link = self._json["version_text"]["link"]
+                self._update_version = str(self._json["version_text"]["version"])
+                # cached update
+                callback(True)
+                return
+
+        # do the check
+        if not self._check_interval_enable:
+            return
+        elif self._async_checking:
+            if self._verbose:
+                print("Skipping async check, already started")
+            return  # already running the bg thread
+        elif self._update_ready is None:
+            self.start_async_check_update(False, callback)
+
+    def check_for_update_now(self, callback=None):
+
+        self._error = None
+        self._error_msg = None
+
+        if self._verbose:
+            print("Check update pressed, first getting current status")
+        if self._async_checking:
+            if self._verbose:
+                print("Skipping async check, already started")
+            return  # already running the bg thread
+        elif self._update_ready is None:
+            self.start_async_check_update(True, callback)
+        else:
+            self._update_ready = None
+            self.start_async_check_update(True, callback)
+
+    # this function is not async, will always return in sequential fashion
+    # but should have a parent which calls it in another thread
+    def check_for_update(self, now=False):
+        if self._verbose:
+            print("Checking for update function")
+
+        # clear the errors if any
+        self._error = None
+        self._error_msg = None
+
+        # avoid running again in, just return past result if found
+        # but if force now check, then still do it
+        if self._update_ready is not None and not now:
+            return (self._update_ready, self._update_version, self._update_link)
+
+        if self._current_version is None:
+            raise ValueError("current_version not yet defined")
+
+        if self._repo is None:
+            raise ValueError("repo not yet defined")
+
+        if self._user is None:
+            raise ValueError("username not yet defined")
+
+        self.set_updater_json()  # self._json
+
+        if not now and not self.past_interval_timestamp():
+            if self._verbose:
+                print("Aborting check for updated, check interval not reached")
+            return (False, None, None)
+
+        # check if using tags or releases
+        # note that if called the first time, this will pull tags from online
+        if self._fake_install:
+            if self._verbose:
+                print("fake_install = True, setting fake version as ready")
+            self._update_ready = True
+            self._update_version = "(999,999,999)"
+            self._update_link = "http://127.0.0.1"
+
+            return (self._update_ready, self._update_version, self._update_link)
+
+        # primary internet call
+        self.get_tags()  # sets self._tags and self._tag_latest
+
+        self._json["last_check"] = str(datetime.now())
+        self.save_updater_json()
+
+        # can be () or ('master') in addition to branches, and version tag
+        new_version = self.version_tuple_from_text(self.tag_latest)
+
+        if len(self._tags) == 0:
+            self._update_ready = False
+            self._update_version = None
+            self._update_link = None
+            return (False, None, None)
+
+        if not self._include_branches:
+            link = self.select_link(self, self._tags[0])
+        else:
+            n = len(self._include_branch_list)
+            if len(self._tags) == n:
+                # effectively means no tags found on repo
+                # so provide the first one as default
+                link = self.select_link(self, self._tags[0])
+            else:
+                link = self.select_link(self, self._tags[n])
+
+        if new_version == ():
+            self._update_ready = False
+            self._update_version = None
+            self._update_link = None
+            return (False, None, None)
+        elif str(new_version).lower() in self._include_branch_list:
+            # handle situation where master/whichever branch is included
+            # however, this code effectively is not triggered now
+            # as new_version will only be tag names, not branch names
+            if not self._include_branch_auto_check:
+                # don't offer update as ready,
+                # but set the link for the default
+                # branch for installing
+                self._update_ready = False
+                self._update_version = new_version
+                self._update_link = link
+                self.save_updater_json()
+                return (True, new_version, link)
+            else:
+                raise ValueError("include_branch_autocheck: NOT YET DEVELOPED")
+                # bypass releases and look at timestamp of last update
+                # from a branch compared to now, see if commit values
+                # match or not.
+
+        else:
+            # situation where branches not included
+
+            if new_version > self._current_version:
+
+                self._update_ready = True
+                self._update_version = new_version
+                self._update_link = link
+                self.save_updater_json()
+                return (True, new_version, link)
+
+        # elif new_version != self._current_version:
+        # 	self._update_ready = False
+        # 	self._update_version = new_version
+        # 	self._update_link = link
+        # 	self.save_updater_json()
+        # 	return (True, new_version, link)
+
+        # if no update, set ready to False from None
+        self._update_ready = False
+        self._update_version = None
+        self._update_link = None
+        return (False, None, None)
+
+    def set_tag(self, name):
+        """Assign the tag name and url to update to"""
+        tg = None
+        for tag in self._tags:
+            if name == tag["name"]:
+                tg = tag
+                break
+        if tg:
+            new_version = self.version_tuple_from_text(self.tag_latest)
+            self._update_version = new_version
+            self._update_link = self.select_link(self, tg)
+        elif self._include_branches and name in self._include_branch_list:
+            # scenario if reverting to a specific branch name instead of tag
+            tg = name
+            link = self.form_branch_url(tg)
+            self._update_version = name  # this will break things
+            self._update_link = link
+        if not tg:
+            raise ValueError("Version tag not found: "+name)
+
+    def run_update(self, force=False, revert_tag=None, clean=False, callback=None):
+        """Runs an install, update, or reversion of an addon from online source
+
+        Arguments:
+            force: Install assigned link, even if self.update_ready is False
+            revert_tag: Version to install, if none uses detected update link
+            clean: not used, but in future could use to totally refresh addon
+            callback: used to run function on update completion
+        """
+        self._json["update_ready"] = False
+        self._json["ignore"] = False  # clear ignore flag
+        self._json["version_text"] = dict()
+
+        if revert_tag is not None:
+            self.set_tag(revert_tag)
+            self._update_ready = True
+
+        # clear the errors if any
+        self._error = None
+        self._error_msg = None
+
+        if self._verbose:
+            print("Running update")
+
+        if self._fake_install:
+            # change to True, to trigger the reload/"update installed" handler
+            if self._verbose:
+                print("fake_install=True")
+                print("Just reloading and running any handler triggers")
+            self._json["just_updated"] = True
+            self.save_updater_json()
+            if self._backup_current is True:
+                self.create_backup()
+            self.reload_addon()
+            self._update_ready = False
+            res = True  # fake "success" zip download flag
+
+        elif not force:
+            if not self._update_ready:
+                if self._verbose:
+                    print("Update stopped, new version not ready")
+                if callback:
+                    callback(
+                        self._addon_package,
+                        "Update stopped, new version not ready")
+                return "Update stopped, new version not ready"
+            elif self._update_link is None:
+                # this shouldn't happen if update is ready
+                if self._verbose:
+                    print("Update stopped, update link unavailable")
+                if callback:
+                    callback(self._addon_package,
+                        "Update stopped, update link unavailable")
+                return "Update stopped, update link unavailable"
+
+            if self._verbose and revert_tag is None:
+                print("Staging update")
+            elif self._verbose:
+                print("Staging install")
+
+            res = self.stage_repository(self._update_link)
+            if not res:
+                print("Error in staging repository: " + str(res))
+                if callback is not None:
+                    callback(self._addon_package, self._error_msg)
+                return self._error_msg
+            res = self.unpack_staged_zip(clean)
+            if res < 0:
+                if callback:
+                    callback(self._addon_package, self._error_msg)
+                return res
+
+        else:
+            if self._update_link is None:
+                if self._verbose:
+                    print("Update stopped, could not get link")
+                return "Update stopped, could not get link"
+            if self._verbose:
+                print("Forcing update")
+
+            res = self.stage_repository(self._update_link)
+            if not res:
+                print("Error in staging repository: " + str(res))
+                if callback:
+                    callback(self._addon_package, self._error_msg)
+                return self._error_msg
+            res = self.unpack_staged_zip(clean)
+            if res < 0:
+                return res
+            # would need to compare against other versions held in tags
+
+        # run the front-end's callback if provided
+        if callback:
+            callback(self._addon_package)
+
+        # return something meaningful, 0 means it worked
+        return 0
+
+    def past_interval_timestamp(self):
+        if not self._check_interval_enable:
+            return True  # ie this exact feature is disabled
+
+        if "last_check" not in self._json or self._json["last_check"] == "":
+            return True
+
+        now = datetime.now()
+        last_check = datetime.strptime(self._json["last_check"], "%Y-%m-%d %H:%M:%S.%f")
+        next_check = last_check
+        offset = timedelta(
+            days=self._check_interval_days + 30 * self._check_interval_months,
+            hours=self._check_interval_hours,
+            minutes=self._check_interval_minutes
+            )
+
+        delta = (now - offset) - last_check
+        if delta.total_seconds() > 0:
+            if self._verbose:
+                print("{} Updater: Time to check for updates!".format(self._addon))
+            return True
+
+        if self._verbose:
+            print("{} Updater: Determined it's not yet time to check for updates".format(self._addon))
+        return False
+
+    def get_json_path(self):
+        """Returns the full path to the JSON state file used by this updater.
+
+        Will also rename old file paths to addon-specific path if found
+        """
+        json_path = os.path.join(self._updater_path, "{}_updater_status.json".format(self._addon_package))
+        old_json_path = os.path.join(self._updater_path, "updater_status.json")
+
+        # rename old file if it exists
+        try:
+            os.rename(old_json_path, json_path)
+        except FileNotFoundError:
+            pass
+        except Exception as err:
+            print("Other OS error occurred while trying to rename old JSON")
+            print(err)
+            self.print_trace()
+        return json_path
+
+    def set_updater_json(self):
+        """Load or initialize JSON dictionary data for updater state"""
+        if self._updater_path is None:
+            raise ValueError("updater_path is not defined")
+        elif not os.path.isdir(self._updater_path):
+            os.makedirs(self._updater_path)
+
+        jpath = self.get_json_path()
+        if os.path.isfile(jpath):
+            with open(jpath) as data_file:
+                self._json = json.load(data_file)
+                if self._verbose:
+                    print("{} Updater: Read in JSON settings from file".format(
+                        self._addon))
+        else:
+            # set data structure
+            self._json = {
+                "last_check": "",
+                "backup_date": "",
+                "update_ready": False,
+                "ignore": False,
+                "just_restored": False,
+                "just_updated": False,
+                "version_text": dict()
+            }
+            self.save_updater_json()
+
+    def save_updater_json(self):
+        # first save the state
+        if self._update_ready:
+            if isinstance(self._update_version, tuple):
+                self._json["update_ready"] = True
+                self._json["version_text"]["link"] = self._update_link
+                self._json["version_text"]["version"] = self._update_version
+            else:
+                self._json["update_ready"] = False
+                self._json["version_text"] = dict()
+        else:
+            self._json["update_ready"] = False
+            self._json["version_text"] = dict()
+
+        jpath = self.get_json_path()
+        outf = open(jpath, 'w')
+        data_out = json.dumps(self._json, indent=4)
+        outf.write(data_out)
+        outf.close()
+        if self._verbose:
+            print(self._addon+": Wrote out updater JSON settings to file, with the contents:")
+            print(self._json)
+
+    def json_reset_postupdate(self):
+        self._json["just_updated"] = False
+        self._json["update_ready"] = False
+        self._json["version_text"] = dict()
+        self.save_updater_json()
+
+    def json_reset_restore(self):
+        self._json["just_restored"] = False
+        self._json["update_ready"] = False
+        self._json["version_text"] = dict()
+        self.save_updater_json()
+        self._update_ready = None  # reset so you could check update again
+
+    def ignore_update(self):
+        self._json["ignore"] = True
+        self.save_updater_json()
+
+    # -------------------------------------------------------------------------
+    # ASYNC stuff
+    # -------------------------------------------------------------------------
+    def start_async_check_update(self, now=False, callback=None):
+        """Start a background thread which will check for updates"""
+        if self._async_checking:
+            return
+        if self._verbose:
+            print("{} updater: Starting background checking thread".format(
+                self._addon))
+        check_thread = threading.Thread(target=self.async_check_update,
+                                        args=(now, callback,))
+        check_thread.daemon = True
+        self._check_thread = check_thread
+        check_thread.start()
+
+    def async_check_update(self, now, callback=None):
+        """Perform update check, run as target of background thread"""
+        self._async_checking = True
+        if self._verbose:
+            print("{} BG thread: Checking for update now in background".format(
+                self._addon))
+
+        try:
+            self.check_for_update(now=now)
+        except Exception as exception:
+            print("Checking for update error:")
+            print(exception)
+            self.print_trace()
+            if not self._error:
+                self._update_ready = False
+                self._update_version = None
+                self._update_link = None
+                self._error = "Error occurred"
+                self._error_msg = "Encountered an error while checking for updates"
+
+        self._async_checking = False
+        self._check_thread = None
+
+        if self._verbose:
+            print("{} BG thread: Finished checking for update, doing callback".format(self._addon))
+        if callback:
+            callback(self._update_ready)
+
+    def stop_async_check_update(self):
+        """Method to give impression of stopping check for update.
+
+        Currently does nothing but allows user to retry/stop blocking UI from
+        hitting a refresh button. This does not actually stop the thread, as it
+        will complete after the connection timeout regardless. If the thread
+        does complete with a successful response, this will be still displayed
+        on next UI refresh (ie no update, or update available).
+        """
+        if self._check_thread is not None:
+            if self._verbose:
+                print("Thread will end in normal course.")
+            # however, "There is no direct kill method on a thread object."
+            # better to let it run its course
+            # self._check_thread.stop()
+        self._async_checking = False
+        self._error = None
+        self._error_msg = None
 
 
 # -----------------------------------------------------------------------------
@@ -1640,105 +1637,105 @@ class SingletonUpdater:
 
 
 class BitbucketEngine:
-	"""Integration to Bitbucket API for git-formatted repositories"""
+    """Integration to Bitbucket API for git-formatted repositories"""
 
-	def __init__(self):
-		self.api_url = 'https://api.bitbucket.org'
-		self.token = None
-		self.name = "bitbucket"
+    def __init__(self):
+        self.api_url = 'https://api.bitbucket.org'
+        self.token = None
+        self.name = "bitbucket"
 
-	def form_repo_url(self, updater):
-		return self.api_url+"/2.0/repositories/"+updater.user+"/"+updater.repo
+    def form_repo_url(self, updater):
+        return self.api_url+"/2.0/repositories/"+updater.user+"/"+updater.repo
 
-	def form_tags_url(self, updater):
-		return self.form_repo_url(updater) + "/refs/tags?sort=-name"
+    def form_tags_url(self, updater):
+        return self.form_repo_url(updater) + "/refs/tags?sort=-name"
 
-	def form_branch_url(self, branch, updater):
-		return self.get_zip_url(branch, updater)
+    def form_branch_url(self, branch, updater):
+        return self.get_zip_url(branch, updater)
 
-	def get_zip_url(self, name, updater):
-		return "https://bitbucket.org/{user}/{repo}/get/{name}.zip".format(
-			user=updater.user,
-			repo=updater.repo,
-			name=name)
+    def get_zip_url(self, name, updater):
+        return "https://bitbucket.org/{user}/{repo}/get/{name}.zip".format(
+            user=updater.user,
+            repo=updater.repo,
+            name=name)
 
-	def parse_tags(self, response, updater):
-		if response is None:
-			return list()
-		return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["name"], updater)} for tag in response["values"]]
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["name"], updater)} for tag in response["values"]]
 
 
 class GithubEngine:
-	"""Integration to Github API"""
+    """Integration to Github API"""
 
-	def __init__(self):
-		self.api_url = 'https://api.github.com'
-		self.token = None
-		self.name = "github"
+    def __init__(self):
+        self.api_url = 'https://api.github.com'
+        self.token = None
+        self.name = "github"
 
-	def form_repo_url(self, updater):
-		return "{}{}{}{}{}".format(self.api_url, "/repos/", updater.user, "/",
-								updater.repo)
+    def form_repo_url(self, updater):
+        return "{}{}{}{}{}".format(self.api_url, "/repos/", updater.user, "/",
+                                updater.repo)
 
-	def form_tags_url(self, updater):
-		if updater.use_releases:
-			return "{}{}".format(self.form_repo_url(updater), "/releases")
-		else:
-			return "{}{}".format(self.form_repo_url(updater), "/tags")
+    def form_tags_url(self, updater):
+        if updater.use_releases:
+            return "{}{}".format(self.form_repo_url(updater), "/releases")
+        else:
+            return "{}{}".format(self.form_repo_url(updater), "/tags")
 
-	def form_branch_list_url(self, updater):
-		return "{}{}".format(self.form_repo_url(updater), "/branches")
+    def form_branch_list_url(self, updater):
+        return "{}{}".format(self.form_repo_url(updater), "/branches")
 
-	def form_branch_url(self, branch, updater):
-		return "{}{}{}".format(self.form_repo_url(updater), "/zipball/",
-							branch)
+    def form_branch_url(self, branch, updater):
+        return "{}{}{}".format(self.form_repo_url(updater), "/zipball/",
+                            branch)
 
-	def parse_tags(self, response, updater):
-		if response is None:
-			return list()
-		return response
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return response
 
 
 class GitlabEngine:
-	"""Integration to GitLab API"""
+    """Integration to GitLab API"""
 
-	def __init__(self):
-		self.api_url = 'https://gitlab.com'
-		self.token = None
-		self.name = "gitlab"
+    def __init__(self):
+        self.api_url = 'https://gitlab.com'
+        self.token = None
+        self.name = "gitlab"
 
-	def form_repo_url(self, updater):
-		return "{}{}{}".format(self.api_url, "/api/v4/projects/", updater.repo)
+    def form_repo_url(self, updater):
+        return "{}{}{}".format(self.api_url, "/api/v4/projects/", updater.repo)
 
-	def form_tags_url(self, updater):
-		return "{}{}".format(self.form_repo_url(updater), "/repository/tags")
+    def form_tags_url(self, updater):
+        return "{}{}".format(self.form_repo_url(updater), "/repository/tags")
 
-	def form_branch_list_url(self, updater):
-		# does not validate branch name.
-		return "{}{}".format(
-			self.form_repo_url(updater), "/repository/branches")
+    def form_branch_list_url(self, updater):
+        # does not validate branch name.
+        return "{}{}".format(
+            self.form_repo_url(updater), "/repository/branches")
 
-	def form_branch_url(self, branch, updater):
-		# Could clash with tag names and if it does, it will
-		# download TAG zip instead of branch zip to get
-		# direct path, would need.
-		return "{}{}{}".format(
-			self.form_repo_url(updater),
-			"/repository/archive.zip?sha=",
-			branch)
+    def form_branch_url(self, branch, updater):
+        # Could clash with tag names and if it does, it will
+        # download TAG zip instead of branch zip to get
+        # direct path, would need.
+        return "{}{}{}".format(
+            self.form_repo_url(updater),
+            "/repository/archive.zip?sha=",
+            branch)
 
-	def get_zip_url(self, sha, updater):
-		return "{base}/repository/archive.zip?sha={sha}".format(
-			base=self.form_repo_url(updater),
-			sha=sha)
+    def get_zip_url(self, sha, updater):
+        return "{base}/repository/archive.zip?sha={sha}".format(
+            base=self.form_repo_url(updater),
+            sha=sha)
 
-	# def get_commit_zip(self, id, updater):
-	# 	return self.form_repo_url(updater)+"/repository/archive.zip?sha:"+id
+    # def get_commit_zip(self, id, updater):
+    # 	return self.form_repo_url(updater)+"/repository/archive.zip?sha:"+id
 
-	def parse_tags(self, response, updater):
-		if response is None:
-			return list()
-		return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["commit"]["id"], updater)} for tag in response]
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return [{"name": tag["name"], "zipball_url": self.get_zip_url(tag["commit"]["id"], updater)} for tag in response]
 
 
 # -----------------------------------------------------------------------------

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -298,9 +298,9 @@ class AddonUpdaterUpdateNow(bpy.types.Operator):
 						print("Updater returned successful")
 					else:
 						print("Updater returned " + str(res) + ", error occurred")
-			except Exception as e:
+			except Exception as expt:
 				updater._error = "Error trying to run update"
-				updater._error_msg = str(e)
+				updater._error_msg = str(expt)
 				updater.print_trace()
 				atr = AddonUpdaterInstallManually.bl_idname.split(".")
 				getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -41,7 +41,7 @@ except Exception as e:
 			self.addon = None
 			self.verbose = False
 			self.use_print_traces = True
-			self.invalidupdater = True  # used to distinguish bad install
+			self.invalid_updater = True  # used to distinguish bad install
 			self.error = None
 			self.error_msg = None
 			self.async_checking = None
@@ -49,7 +49,7 @@ except Exception as e:
 		def clear_state(self):
 			self.addon = None
 			self.verbose = False
-			self.invalidupdater = True
+			self.invalid_updater = True
 			self.error = None
 			self.error_msg = None
 			self.async_checking = None
@@ -150,7 +150,7 @@ class addon_updater_install_popup(bpy.types.Operator):
 
 	def draw(self, context):
 		layout = self.layout
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			layout.label(text="Updater module error")
 			return
 		elif updater.update_ready:
@@ -180,7 +180,7 @@ class addon_updater_install_popup(bpy.types.Operator):
 	def execute(self, context):
 
 		# in case of error importing updater
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return {'CANCELLED'}
 
 		if updater.manual_only:
@@ -226,7 +226,7 @@ class addon_updater_check_now(bpy.types.Operator):
 	bl_options = {'REGISTER', 'INTERNAL'}
 
 	def execute(self, context):
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return {'CANCELLED'}
 
 		if updater.async_checking and updater.error is None:
@@ -278,7 +278,7 @@ class addon_updater_update_now(bpy.types.Operator):
 	def execute(self, context):
 
 		# in case of error importing updater
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return {'CANCELLED'}
 
 		if updater.manual_only:
@@ -328,7 +328,7 @@ class addon_updater_update_target(bpy.types.Operator):
 
 	def target_version(self, context):
 		# in case of error importing updater
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			ret = []
 
 		ret = []
@@ -356,7 +356,7 @@ class addon_updater_update_target(bpy.types.Operator):
 
 	@classmethod
 	def poll(cls, context):
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return False
 		return updater.update_ready is not None and len(updater.tags) > 0
 
@@ -365,7 +365,7 @@ class addon_updater_update_target(bpy.types.Operator):
 
 	def draw(self, context):
 		layout = self.layout
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			layout.label(text="Updater error")
 			return
 		split = layout_split(layout, factor=0.5)
@@ -377,7 +377,7 @@ class addon_updater_update_target(bpy.types.Operator):
 	def execute(self, context):
 
 		# in case of error importing updater
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return {'CANCELLED'}
 
 		res = updater.run_update(
@@ -417,7 +417,7 @@ class addon_updater_install_manually(bpy.types.Operator):
 	def draw(self, context):
 		layout = self.layout
 
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			layout.label(text="Updater error")
 			return
 
@@ -481,7 +481,7 @@ class addon_updater_updated_successful(bpy.types.Operator):
 	def draw(self, context):
 		layout = self.layout
 
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			layout.label(text="Updater error")
 			return
 
@@ -562,7 +562,7 @@ class addon_updater_restore_backup(bpy.types.Operator):
 
 	def execute(self, context):
 		# in case of error importing updater
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return {'CANCELLED'}
 		updater.restore_backup()
 		return {'FINISHED'}
@@ -577,7 +577,7 @@ class addon_updater_ignore(bpy.types.Operator):
 
 	@classmethod
 	def poll(cls, context):
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return False
 		elif updater.update_ready:
 			return True
@@ -586,7 +586,7 @@ class addon_updater_ignore(bpy.types.Operator):
 
 	def execute(self, context):
 		# in case of error importing updater
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return {'CANCELLED'}
 		updater.ignore_update()
 		self.report({"INFO"}, "Open addon preferences for updater options")
@@ -609,7 +609,7 @@ class addon_updater_end_background(bpy.types.Operator):
 
 	def execute(self, context):
 		# in case of error importing updater
-		if updater.invalidupdater:
+		if updater.invalid_updater:
 			return {'CANCELLED'}
 		updater.stop_async_check_update()
 		return {'FINISHED'}
@@ -621,8 +621,8 @@ class addon_updater_end_background(bpy.types.Operator):
 
 
 # global vars used to prevent duplicate popup handlers
-ran_autocheck_install_popup = False
-ran_update_sucess_popup = False
+ran_auto_check_install_popup = False
+ran_update_success_popup = False
 
 # global var for preventing successive calls
 ran_background_check = False
@@ -630,11 +630,11 @@ ran_background_check = False
 
 @persistent
 def updater_run_success_popup_handler(scene):
-	global ran_update_sucess_popup
-	ran_update_sucess_popup = True
+	global ran_update_success_popup
+	ran_update_success_popup = True
 
 	# in case of error importing updater
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 
 	try:
@@ -653,11 +653,11 @@ def updater_run_success_popup_handler(scene):
 
 @persistent
 def updater_run_install_popup_handler(scene):
-	global ran_autocheck_install_popup
-	ran_autocheck_install_popup = True
+	global ran_auto_check_install_popup
+	ran_auto_check_install_popup = True
 
 	# in case of error importing updater
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 
 	try:
@@ -694,10 +694,10 @@ def updater_run_install_popup_handler(scene):
 
 def background_update_callback(update_ready):
 	"""Passed into the updater, background thread updater"""
-	global ran_autocheck_install_popup
+	global ran_auto_check_install_popup
 
 	# in case of error importing updater
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 	if not updater.showpopups:
 		return
@@ -712,7 +712,7 @@ def background_update_callback(update_ready):
 		handlers = bpy.app.handlers.depsgraph_update_post
 	in_handles = updater_run_install_popup_handler in handlers
 
-	if in_handles or ran_autocheck_install_popup:
+	if in_handles or ran_auto_check_install_popup:
 		return
 
 	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
@@ -721,7 +721,7 @@ def background_update_callback(update_ready):
 	else:  # 2.8x
 		bpy.app.handlers.depsgraph_update_post.append(
 				updater_run_install_popup_handler)
-	ran_autocheck_install_popup = True
+	ran_auto_check_install_popup = True
 
 
 def post_update_callback(module_name, res=None):
@@ -736,7 +736,7 @@ def post_update_callback(module_name, res=None):
 	"""
 
 	# in case of error importing updater
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 
 	if res is None:
@@ -747,8 +747,8 @@ def post_update_callback(module_name, res=None):
 
 		atr = addon_updater_updated_successful.bl_idname.split(".")
 		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-		global ran_update_sucess_popup
-		ran_update_sucess_popup = True
+		global ran_update_success_popup
+		ran_update_success_popup = True
 	else:
 		# some kind of error occurred and it was unable to install,
 		# offer manual download instead
@@ -771,7 +771,7 @@ def check_for_update_background():
 
 	*Could* be called on register, but would be bad practice.
 	"""
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 	global ran_background_check
 	if ran_background_check:
@@ -805,7 +805,7 @@ def check_for_update_background():
 
 def check_for_update_nonthreaded(self, context):
 	"""Can be placed in front of other operators to launch when pressed"""
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 
 	# only check if it's ready, ie after the time interval specified
@@ -837,10 +837,10 @@ def showReloadPopup():
 
 	Must be enabled by developer
 	"""
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 	saved_state = updater.json
-	global ran_update_sucess_popup
+	global ran_update_success_popup
 
 	has_state = saved_state is not None
 	just_updated = "just_updated" in saved_state
@@ -863,7 +863,7 @@ def showReloadPopup():
 		handlers = bpy.app.handlers.depsgraph_update_post
 	in_handles = updater_run_success_popup_handler in handlers
 
-	if in_handles or ran_update_sucess_popup:
+	if in_handles or ran_update_success_popup:
 		return
 
 	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
@@ -872,7 +872,7 @@ def showReloadPopup():
 	else:  # 2.8x
 		bpy.app.handlers.depsgraph_update_post.append(
 				updater_run_success_popup_handler)
-	ran_update_sucess_popup = True
+	ran_update_success_popup = True
 
 
 # -----------------------------------------------------------------------------
@@ -888,7 +888,7 @@ def update_notice_box_ui(self, context):
 	or ignore popup. Ideal to be placed at the end / beginning of a panel
 	"""
 
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		return
 
 	saved_state = updater.json
@@ -951,7 +951,7 @@ def update_settings_ui(self, context, element=None):
 	box = element.box()
 
 	# in case of error importing updater
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		box.label(text="Error initializing updater code:")
 		box.label(text=updater.error_msg)
 		return
@@ -1121,7 +1121,7 @@ def update_settings_ui_condensed(self, context, element=None):
 	row = element.row()
 
 	# in case of error importing updater
-	if updater.invalidupdater:
+	if updater.invalid_updater:
 		row.label(text="Error initializing updater code:")
 		row.label(text=updater.error_msg)
 		return
@@ -1245,7 +1245,7 @@ def skip_tag_function(self, tag):
 	"""
 
 	# in case of error importing updater
-	if self.invalidupdater:
+	if self.invalid_updater:
 		return False
 
 	# ---- write any custom code here, return true to disallow version ---- #
@@ -1461,7 +1461,7 @@ def register(bl_info):
 	# check for update in user preferences found a new version, show a popup
 	# (at most once per blender session, and it provides an option to ignore
 	# for future sessions); default behavior is set to True
-	updater.showpopups = True
+	updater.show_popups = True
 	# note: if set to false, there will still be an "update ready" box drawn
 	# using the `update_notice_box_ui` panel function.
 
@@ -1511,11 +1511,11 @@ def unregister():
 	# clear global vars since they may persist if not restarting blender
 	updater.clear_state()  # clear internal vars, avoids reloading oddities
 
-	global ran_autocheck_install_popup
-	ran_autocheck_install_popup = False
+	global ran_auto_check_install_popup
+	ran_auto_check_install_popup = False
 
-	global ran_update_sucess_popup
-	ran_update_sucess_popup = False
+	global ran_update_success_popup
+	ran_update_success_popup = False
 
 	global ran_background_check
 	ran_background_check = False

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -833,7 +833,7 @@ def check_for_update_nonthreaded(self, context):
 		self.report({'INFO'}, "No update ready")
 
 
-def showReloadPopup():
+def show_reload_popup():
 	"""For use in register only, to show popup after re-enabling the addon
 
 	Must be enabled by developer
@@ -1499,7 +1499,7 @@ def register(bl_info):
 	# special situation: we just updated the addon, show a popup
 	# to tell the user it worked
 	# should be enclosed in try/catch in case other issues arise
-	showReloadPopup()
+	show_reload_popup()
 
 
 def unregister():

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -131,6 +131,7 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
 		default=False,
 		options={'HIDDEN'}
 	)
+
 	ignore_enum = bpy.props.EnumProperty(
 		name="Process update",
 		description="Decide to install, ignore, or defer new addon update",
@@ -342,7 +343,7 @@ class AddonUpdaterUpdateTarget(bpy.types.Operator):
 		name="Target version to install",
 		description="Select the version to install",
 		items=target_version
-		)
+	)
 
 	# if true, run clean install - ie remove all files before adding new
 	# equivalent to deleting the addon and reinstalling, except the
@@ -401,7 +402,7 @@ class AddonUpdaterUpdateTarget(bpy.types.Operator):
 class AddonUpdaterInstallManually(bpy.types.Operator):
 	"""As a fallback, direct the user to download the addon manually"""
 	bl_label = "Install update manually"
-	bl_idname = updater.addon+".updater_install_manually"
+	bl_idname = updater.addon + ".updater_install_manually"
 	bl_description = "Proceed to manually install update"
 	bl_options = {'REGISTER', 'INTERNAL'}
 
@@ -409,7 +410,7 @@ class AddonUpdaterInstallManually(bpy.types.Operator):
 		name="Error Occurred",
 		default="",
 		options={'HIDDEN'}
-		)
+	)
 
 	def invoke(self, context, event):
 		return context.window_manager.invoke_popup(self)
@@ -473,7 +474,7 @@ class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
 		name="Error Occurred",
 		default="",
 		options={'HIDDEN'}
-		)
+	)
 
 	def invoke(self, context, event):
 		return context.window_manager.invoke_props_popup(self, event)
@@ -571,7 +572,7 @@ class AddonUpdaterRestoreBackup(bpy.types.Operator):
 class AddonUpdaterIgnore(bpy.types.Operator):
 	"""Prevent future update notice popups"""
 	bl_label = "Ignore update"
-	bl_idname = updater.addon+".updater_ignore"
+	bl_idname = updater.addon + ".updater_ignore"
 	bl_description = "Ignore update to prevent future popups"
 	bl_options = {'REGISTER', 'INTERNAL'}
 
@@ -596,7 +597,7 @@ class AddonUpdaterIgnore(bpy.types.Operator):
 class AddonUpdaterEndBackground(bpy.types.Operator):
 	"""Stop checking for update in the background"""
 	bl_label = "End background check"
-	bl_idname = updater.addon+".end_background_check"
+	bl_idname = updater.addon + ".end_background_check"
 	bl_description = "Stop checking for update in the background"
 	bl_options = {'REGISTER', 'INTERNAL'}
 
@@ -878,8 +879,6 @@ def showReloadPopup():
 # -----------------------------------------------------------------------------
 # Example UI integrations
 # -----------------------------------------------------------------------------
-
-
 def update_notice_box_ui(self, context):
 	""" Panel - Update Available for placement at end/beginning of panel
 
@@ -1054,7 +1053,7 @@ def update_settings_ui(self, context, element=None):
 		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update now to "+str(updater.update_version))
+					   text="Update now to " + str(updater.update_version))
 		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(AddonUpdaterCheckNow.bl_idname,
@@ -1063,7 +1062,7 @@ def update_settings_ui(self, context, element=None):
 	elif updater.update_ready and updater.manual_only:
 		col.scale_y = 2
 		col.operator("wm.url_open",
-				text="Download "+str(updater.update_version)).url = updater.website
+				text="Download " + str(updater.update_version)).url = updater.website
 	else:  # i.e. that updater.update_ready == False
 		sub_col = col.row(align=True)
 		sub_col.scale_y = 1
@@ -1195,7 +1194,7 @@ def update_settings_ui_condensed(self, context, element=None):
 		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update now to "+str(updater.update_version))
+					   text="Update now to " + str(updater.update_version))
 		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(AddonUpdaterCheckNow.bl_idname,
@@ -1204,7 +1203,7 @@ def update_settings_ui_condensed(self, context, element=None):
 	elif updater.update_ready and updater.manual_only:
 		col.scale_y = 2
 		col.operator("wm.url_open",
-				text="Download "+str(updater.update_version)).url = updater.website
+				text="Download " + str(updater.update_version)).url = updater.website
 	else:  # i.e. that updater.update_ready == False
 		sub_col = col.row(align=True)
 		sub_col.scale_y = 1

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -672,7 +672,7 @@ def updater_run_install_popup_handler(scene):
 		pass
 
 	if "ignore" in updater.json and updater.json["ignore"]:
-		return # don't do popup if ignore pressed
+		return  # don't do popup if ignore pressed
 	# elif type(updater.update_version) != type((0,0,0)):
 	# 	# likely was from master or another branch, shouldn't trigger popup
 	# 	updater.json_reset_restore()

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -1260,7 +1260,7 @@ def skip_tag_function(self, tag):
 
 	# function converting string to tuple, ignoring e.g. leading 'v'
 	tupled = self.version_tuple_from_text(tag["name"])
-	if type(tupled) != type((1, 2, 3)):
+	if not isinstance(tupled, tuple):
 		return True
 
 	# select the min tag version - change tuple accordingly

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -245,10 +245,10 @@ class addon_updater_check_now(bpy.types.Operator):
 
 		updater.set_check_interval(
 			enable=settings.auto_check_update,
-			months=settings.updater_intrval_months,
-			days=settings.updater_intrval_days,
-			hours=settings.updater_intrval_hours,
-			minutes=settings.updater_intrval_minutes)  # optional, if auto_check_update
+			months=settings.updater_interval_months,
+			days=settings.updater_interval_days,
+			hours=settings.updater_interval_hours,
+			minutes=settings.updater_interval_minutes)  # optional, if auto_check_update
 
 		# input is an optional callback function
 		# this function should take a bool input, if true: update ready

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -369,10 +369,10 @@ class addon_updater_update_target(bpy.types.Operator):
 			layout.label(text="Updater error")
 			return
 		split = layout_split(layout, factor=0.5)
-		subcol = split.column()
-		subcol.label(text="Select install version")
-		subcol = split.column()
-		subcol.prop(self, "target", text="")
+		sub_col = split.column()
+		sub_col.label(text="Select install version")
+		sub_col = split.column()
+		sub_col.prop(self, "target", text="")
 
 	def execute(self, context):
 
@@ -976,33 +976,33 @@ def update_settings_ui(self, context, element=None):
 			return
 
 	split = layout_split(row, factor=0.4)
-	subcol = split.column()
-	subcol.prop(settings, "auto_check_update")
-	subcol = split.column()
+	sub_col = split.column()
+	sub_col.prop(settings, "auto_check_update")
+	sub_col = split.column()
 
 	if not settings.auto_check_update:
-		subcol.enabled = False
-	subrow = subcol.row()
-	subrow.label(text="Interval between checks")
-	subrow = subcol.row(align=True)
-	checkcol = subrow.column(align=True)
-	checkcol.prop(settings, "updater_intrval_months")
-	checkcol = subrow.column(align=True)
-	checkcol.prop(settings, "updater_intrval_days")
-	checkcol = subrow.column(align=True)
+		sub_col.enabled = False
+	sub_row = sub_col.row()
+	sub_row.label(text="Interval between checks")
+	sub_row = sub_col.row(align=True)
+	check_col = sub_row.column(align=True)
+	check_col.prop(settings, "updater_interval_months")
+	check_col = sub_row.column(align=True)
+	check_col.prop(settings, "updater_interval_days")
+	check_col = sub_row.column(align=True)
 
 	# Consider un-commenting for local dev (e.g. to set shorter intervals)
-	# checkcol.prop(settings,"updater_intrval_hours")
-	# checkcol = subrow.column(align=True)
-	# checkcol.prop(settings,"updater_intrval_minutes")
+	# check_col.prop(settings,"updater_interval_hours")
+	# check_col = sub_row.column(align=True)
+	# check_col.prop(settings,"updater_interval_minutes")
 
 	# checking / managing updates
 	row = box.row()
 	col = row.column()
 	if updater.error is not None:
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		if "ssl" in updater.error_msg.lower():
 			split.enabled = True
@@ -1012,7 +1012,7 @@ def update_settings_ui(self, context, element=None):
 			split.enabled = False
 			split.operator(addon_updater_check_now.bl_idname,
 						text=updater.error)
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
@@ -1021,14 +1021,14 @@ def update_settings_ui(self, context, element=None):
 		col.scale_y = 2
 		col.operator(addon_updater_check_now.bl_idname)
 	elif updater.update_ready is None:  # async is running
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="Checking...")
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_end_background.bl_idname,
 						text="", icon="X")
@@ -1037,25 +1037,25 @@ def update_settings_ui(self, context, element=None):
 			len(updater.tags) == len(updater.include_branch_list) and not \
 			updater.manual_only:
 		# no releases found, but still show the appropriate branch
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_update_now.bl_idname,
 					text="Update directly to " + str(updater.include_branch_list[0]))
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
 
 	elif updater.update_read and not updater.manual_only:
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_update_now.bl_idname,
 					text="Update now to "+str(updater.update_version))
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
@@ -1065,14 +1065,14 @@ def update_settings_ui(self, context, element=None):
 		col.operator("wm.url_open",
 				text="Download "+str(updater.update_version)).url = updater.website
 	else:  # i.e. that updater.update_ready == False
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="Addon is up to date")
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
@@ -1087,24 +1087,24 @@ def update_settings_ui(self, context, element=None):
 		else:
 			col.operator(addon_updater_update_target.bl_idname,
 					text="Reinstall / install old version")
-		lastdate = "none found"
-		backuppath = os.path.join(updater.stage_path, "backup")
-		if "backup_date" in updater.json and os.path.isdir(backuppath):
+		last_date = "none found"
+		backup_path = os.path.join(updater.stage_path, "backup")
+		if "backup_date" in updater.json and os.path.isdir(backup_path):
 			if updater.json["backup_date"] == "":
-				lastdate = "Date not found"
+				last_date = "Date not found"
 			else:
-				lastdate = updater.json["backup_date"]
-		backuptext = "Restore addon backup ({})".format(lastdate)
-		col.operator(addon_updater_restore_backup.bl_idname, text=backuptext)
+				last_date = updater.json["backup_date"]
+		backup_text = "Restore addon backup ({})".format(last_date)
+		col.operator(addon_updater_restore_backup.bl_idname, text=backup_text)
 
 	row = box.row()
 	row.scale_y = 0.7
-	lastcheck = updater.json["last_check"]
+	last_check = updater.json["last_check"]
 	if updater.error is not None and updater.error_msg is not None:
 		row.label(text=updater.error_msg)
-	elif lastcheck != "" and lastcheck is not None:
-		lastcheck = lastcheck[0: lastcheck.index(".")]
-		row.label(text="Last update check: " + lastcheck)
+	elif last_check is not "" and last_check is not None:
+		last_check = last_check[0: last_check.index(".")]
+		row.label(text="Last update check: " + last_check)
 	else:
 		row.label(text="Last update check: Never")
 
@@ -1143,9 +1143,9 @@ def update_settings_ui_condensed(self, context, element=None):
 
 	col = row.column()
 	if updater.error is not None:
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		if "ssl" in updater.error_msg.lower():
 			split.enabled = True
@@ -1155,7 +1155,7 @@ def update_settings_ui_condensed(self, context, element=None):
 			split.enabled = False
 			split.operator(addon_updater_check_now.bl_idname,
 						text=updater.error)
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
@@ -1164,13 +1164,13 @@ def update_settings_ui_condensed(self, context, element=None):
 		col.scale_y = 2
 		col.operator(addon_updater_check_now.bl_idname)
 	elif updater.update_ready is None:  # async is running
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname, text="Checking...")
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_end_background.bl_idname, text="", icon="X")
 
@@ -1178,25 +1178,25 @@ def update_settings_ui_condensed(self, context, element=None):
 			len(updater.tags) == len(updater.include_branch_list) and not \
 			updater.manual_only:
 		# no releases found, but still show the appropriate branch
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_update_now.bl_idname,
 					text="Update directly to " + str(updater.include_branch_list[0]))
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
 
 	elif updater.update_ready and not updater.manual_only:
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_update_now.bl_idname,
 					text="Update now to "+str(updater.update_version))
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
@@ -1206,14 +1206,14 @@ def update_settings_ui_condensed(self, context, element=None):
 		col.operator("wm.url_open",
 				text="Download "+str(updater.update_version)).url = updater.website
 	else:  # i.e. that updater.update_ready == False
-		subcol = col.row(align=True)
-		subcol.scale_y = 1
-		split = subcol.split(align=True)
+		sub_col = col.row(align=True)
+		sub_col.scale_y = 1
+		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="Addon is up to date")
-		split = subcol.split(align=True)
+		split = sub_col.split(align=True)
 		split.scale_y = 2
 		split.operator(addon_updater_check_now.bl_idname,
 						text="", icon="FILE_REFRESH")
@@ -1223,12 +1223,12 @@ def update_settings_ui_condensed(self, context, element=None):
 
 	row = element.row()
 	row.scale_y = 0.7
-	lastcheck = updater.json["last_check"]
+	last_check = updater.json["last_check"]
 	if updater.error is not None and updater.error_msg is not None:
 		row.label(text=updater.error_msg)
-	elif lastcheck != "" and lastcheck is not None:
-		lastcheck = lastcheck[0: lastcheck.index(".")]
-		row.label(text="Last check: " + lastcheck)
+	elif last_check != "" and last_check is not None:
+		last_check = last_check[0: last_check.index(".")]
+		row.label(text="Last check: " + last_check)
 	else:
 		row.label(text="Last check: Never")
 
@@ -1281,7 +1281,7 @@ def skip_tag_function(self, tag):
 def select_link_function(self, tag):
 	"""Only customize if trying to leverage "attachments" in *GitHub* releases
 
-	A way to select from one or multiple attached donwloadable files from the
+	A way to select from one or multiple attached downloadable files from the
 	server, instead of downloading the default release/tag source code
 	"""
 
@@ -1396,7 +1396,7 @@ def register(bl_info):
 	# if you want to automatically update resources/non py files, add them
 	# as a part of the pattern list below so they will always be overwritten by an
 	# update. If a pattern file is not found in new update, no action is taken
-	# This does NOT detele anything, only defines what is allowed to be overwritten
+	# This does NOT delete anything, only defines what is allowed to be overwritten
 	updater.overwrite_patterns = ["*.png", "*.jpg", "README.md", "LICENSE.txt"]
 	# updater.overwrite_patterns = []
 	# other examples:

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -36,7 +36,7 @@ except Exception as e:
 	print(str(e))
 	traceback.print_exc()
 
-	class Singleton_updater_none(object):
+	class SingletonUpdaterNone(object):
 		def __init__(self):
 			self.addon = None
 			self.verbose = False
@@ -58,7 +58,7 @@ except Exception as e:
 
 		def check_for_update(self): pass
 
-	updater = Singleton_updater_none()
+	updater = SingletonUpdaterNone()
 	updater.error = "Error initializing updater module"
 	updater.error_msg = str(e)
 
@@ -115,7 +115,7 @@ def get_user_preferences(context=None):
 
 
 # simple popup for prompting checking for update & allow to install if available
-class addon_updater_install_popup(bpy.types.Operator):
+class AddonUpdaterInstallPopup(bpy.types.Operator):
 	"""Check and install update if available"""
 	bl_label = "Update {x} addon".format(x=updater.addon)
 	bl_idname = updater.addon+".updater_install_popup"
@@ -209,7 +209,7 @@ class addon_updater_install_popup(bpy.types.Operator):
 			_ = updater.check_for_update(now=True)
 
 			# re-launch this dialog
-			atr = addon_updater_install_popup.bl_idname.split(".")
+			atr = AddonUpdaterInstallPopup.bl_idname.split(".")
 			getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 		else:
 			if updater.verbose:
@@ -218,7 +218,7 @@ class addon_updater_install_popup(bpy.types.Operator):
 
 
 # User preference check-now operator
-class addon_updater_check_now(bpy.types.Operator):
+class AddonUpdaterCheckNow(bpy.types.Operator):
 	bl_label = "Check now for "+updater.addon+" update"
 	bl_idname = updater.addon+".updater_check_now"
 	bl_description = "Check now for an update to the {x} addon".format(
@@ -258,7 +258,7 @@ class addon_updater_check_now(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-class addon_updater_update_now(bpy.types.Operator):
+class AddonUpdaterUpdateNow(bpy.types.Operator):
 	bl_label = "Update " + updater.addon + " addon now"
 	bl_idname = updater.addon + ".updater_update_now"
 	bl_description = "Update to the latest version of the {x} addon".format(
@@ -301,12 +301,12 @@ class addon_updater_update_now(bpy.types.Operator):
 				updater._error = "Error trying to run update"
 				updater._error_msg = str(e)
 				updater.print_trace()
-				atr = addon_updater_install_manually.bl_idname.split(".")
+				atr = AddonUpdaterInstallManually.bl_idname.split(".")
 				getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 		elif updater.update_ready is None:
 			(update_ready, version, link) = updater.check_for_update(now=True)
 			# re-launch this dialog
-			atr = addon_updater_install_popup.bl_idname.split(".")
+			atr = AddonUpdaterInstallPopup.bl_idname.split(".")
 			getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 
 		elif not updater.update_ready:
@@ -319,7 +319,7 @@ class addon_updater_update_now(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-class addon_updater_update_target(bpy.types.Operator):
+class AddonUpdaterUpdateTarget(bpy.types.Operator):
 	bl_label = updater.addon+" version target"
 	bl_idname = updater.addon+".updater_update_target"
 	bl_description = "Install a targeted version of the {x} addon".format(
@@ -398,7 +398,7 @@ class addon_updater_update_target(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-class addon_updater_install_manually(bpy.types.Operator):
+class AddonUpdaterInstallManually(bpy.types.Operator):
 	"""As a fallback, direct the user to download the addon manually"""
 	bl_label = "Install update manually"
 	bl_idname = updater.addon+".updater_install_manually"
@@ -462,7 +462,7 @@ class addon_updater_install_manually(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-class addon_updater_updated_successful(bpy.types.Operator):
+class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
 	"""Addon in place, popup telling user it completed or what went wrong"""
 	bl_label = "Installation Report"
 	bl_idname = updater.addon+".updater_update_successful"
@@ -546,7 +546,7 @@ class addon_updater_updated_successful(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-class addon_updater_restore_backup(bpy.types.Operator):
+class AddonUpdaterRestoreBackup(bpy.types.Operator):
 	"""Restore addon from backup"""
 	bl_label = "Restore backup"
 	bl_idname = updater.addon+".updater_restore_backup"
@@ -568,7 +568,7 @@ class addon_updater_restore_backup(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-class addon_updater_ignore(bpy.types.Operator):
+class AddonUpdaterIgnore(bpy.types.Operator):
 	"""Prevent future update notice popups"""
 	bl_label = "Ignore update"
 	bl_idname = updater.addon+".updater_ignore"
@@ -593,7 +593,7 @@ class addon_updater_ignore(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-class addon_updater_end_background(bpy.types.Operator):
+class AddonUpdaterEndBackground(bpy.types.Operator):
 	"""Stop checking for update in the background"""
 	bl_label = "End background check"
 	bl_idname = updater.addon+".end_background_check"
@@ -647,7 +647,7 @@ def updater_run_success_popup_handler(scene):
 	except:
 		pass
 
-	atr = addon_updater_updated_successful.bl_idname.split(".")
+	atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
 	getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 
 
@@ -688,7 +688,7 @@ def updater_run_install_popup_handler(scene):
 						updater.addon))
 			updater.json_reset_restore()
 			return
-	atr = addon_updater_install_popup.bl_idname.split(".")
+	atr = AddonUpdaterInstallPopup.bl_idname.split(".")
 	getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 
 
@@ -745,14 +745,14 @@ def post_update_callback(module_name, res=None):
 		if updater.verbose:
 			print("{} updater: Running post update callback".format(updater.addon))
 
-		atr = addon_updater_updated_successful.bl_idname.split(".")
+		atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
 		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 		global ran_update_success_popup
 		ran_update_success_popup = True
 	else:
 		# some kind of error occurred and it was unable to install,
 		# offer manual download instead
-		atr = addon_updater_updated_successful.bl_idname.split(".")
+		atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
 		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT', error=res)
 	return
 
@@ -824,7 +824,7 @@ def check_for_update_nonthreaded(self, context):
 
 	(update_ready, version, link) = updater.check_for_update(now=False)
 	if update_ready:
-		atr = addon_updater_install_popup.bl_idname.split(".")
+		atr = AddonUpdaterInstallPopup.bl_idname.split(".")
 		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 	else:
 		if updater.verbose:
@@ -922,16 +922,16 @@ def update_notice_box_ui(self, context):
 	split = row.split(align=True)
 	colL = split.column(align=True)
 	colL.scale_y = 1.5
-	colL.operator(addon_updater_ignore.bl_idname, icon="X", text="Ignore")
+	colL.operator(AddonUpdaterIgnore.bl_idname, icon="X", text="Ignore")
 	colR = split.column(align=True)
 	colR.scale_y = 1.5
 	if not updater.manual_only:
-		colR.operator(addon_updater_update_now.bl_idname,
-						text="Update", icon="LOOP_FORWARDS")
+		colR.operator(AddonUpdaterUpdateNow.bl_idname,
+					  text="Update", icon="LOOP_FORWARDS")
 		col.operator("wm.url_open", text="Open website").url = updater.website
 		# col.operator("wm.url_open",text="Direct download").url=updater.update_link
-		col.operator(addon_updater_install_manually.bl_idname,
-			text="Install manually")
+		col.operator(AddonUpdaterInstallManually.bl_idname,
+					 text="Install manually")
 	else:
 		# col.operator("wm.url_open",text="Direct download").url=updater.update_link
 		col.operator("wm.url_open", text="Get it now").url = updater.website
@@ -1006,32 +1006,32 @@ def update_settings_ui(self, context, element=None):
 		split.scale_y = 2
 		if "ssl" in updater.error_msg.lower():
 			split.enabled = True
-			split.operator(addon_updater_install_manually.bl_idname,
-						text=updater.error)
+			split.operator(AddonUpdaterInstallManually.bl_idname,
+						   text=updater.error)
 		else:
 			split.enabled = False
-			split.operator(addon_updater_check_now.bl_idname,
-						text=updater.error)
+			split.operator(AddonUpdaterCheckNow.bl_idname,
+						   text=updater.error)
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	elif updater.update_ready is None and not updater.async_checking:
 		col.scale_y = 2
-		col.operator(addon_updater_check_now.bl_idname)
+		col.operator(AddonUpdaterCheckNow.bl_idname)
 	elif updater.update_ready is None:  # async is running
 		sub_col = col.row(align=True)
 		sub_col.scale_y = 1
 		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="Checking...")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="Checking...")
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_end_background.bl_idname,
-						text="", icon="X")
+		split.operator(AddonUpdaterEndBackground.bl_idname,
+					   text="", icon="X")
 
 	elif updater.include_branches and \
 			len(updater.tags) == len(updater.include_branch_list) and not \
@@ -1041,24 +1041,24 @@ def update_settings_ui(self, context, element=None):
 		sub_col.scale_y = 1
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_update_now.bl_idname,
-					text="Update directly to " + str(updater.include_branch_list[0]))
+		split.operator(AddonUpdaterUpdateNow.bl_idname,
+					   text="Update directly to " + str(updater.include_branch_list[0]))
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	elif updater.update_read and not updater.manual_only:
 		sub_col = col.row(align=True)
 		sub_col.scale_y = 1
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_update_now.bl_idname,
-					text="Update now to "+str(updater.update_version))
+		split.operator(AddonUpdaterUpdateNow.bl_idname,
+					   text="Update now to "+str(updater.update_version))
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	elif updater.update_ready and updater.manual_only:
 		col.scale_y = 2
@@ -1070,23 +1070,23 @@ def update_settings_ui(self, context, element=None):
 		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="Addon is up to date")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="Addon is up to date")
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	if not updater.manual_only:
 		col = row.column(align=True)
-		# col.operator(addon_updater_update_target.bl_idname,
+		# col.operator(AddonUpdaterUpdateTarget.bl_idname,
 		if updater.include_branches and len(updater.include_branch_list) > 0:
 			branch = updater.include_branch_list[0]
-			col.operator(addon_updater_update_target.bl_idname,
-					text="Install latest {} / old version".format(branch))
+			col.operator(AddonUpdaterUpdateTarget.bl_idname,
+						 text="Install latest {} / old version".format(branch))
 		else:
-			col.operator(addon_updater_update_target.bl_idname,
-					text="Reinstall / install old version")
+			col.operator(AddonUpdaterUpdateTarget.bl_idname,
+						 text="Reinstall / install old version")
 		last_date = "none found"
 		backup_path = os.path.join(updater.stage_path, "backup")
 		if "backup_date" in updater.json and os.path.isdir(backup_path):
@@ -1095,7 +1095,7 @@ def update_settings_ui(self, context, element=None):
 			else:
 				last_date = updater.json["backup_date"]
 		backup_text = "Restore addon backup ({})".format(last_date)
-		col.operator(addon_updater_restore_backup.bl_idname, text=backup_text)
+		col.operator(AddonUpdaterRestoreBackup.bl_idname, text=backup_text)
 
 	row = box.row()
 	row.scale_y = 0.7
@@ -1149,30 +1149,30 @@ def update_settings_ui_condensed(self, context, element=None):
 		split.scale_y = 2
 		if "ssl" in updater.error_msg.lower():
 			split.enabled = True
-			split.operator(addon_updater_install_manually.bl_idname,
-						text=updater.error)
+			split.operator(AddonUpdaterInstallManually.bl_idname,
+						   text=updater.error)
 		else:
 			split.enabled = False
-			split.operator(addon_updater_check_now.bl_idname,
-						text=updater.error)
+			split.operator(AddonUpdaterCheckNow.bl_idname,
+						   text=updater.error)
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	elif updater.update_ready is None and not updater.async_checking:
 		col.scale_y = 2
-		col.operator(addon_updater_check_now.bl_idname)
+		col.operator(AddonUpdaterCheckNow.bl_idname)
 	elif updater.update_ready is None:  # async is running
 		sub_col = col.row(align=True)
 		sub_col.scale_y = 1
 		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname, text="Checking...")
+		split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_end_background.bl_idname, text="", icon="X")
+		split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
 
 	elif updater.include_branches and \
 			len(updater.tags) == len(updater.include_branch_list) and not \
@@ -1182,24 +1182,24 @@ def update_settings_ui_condensed(self, context, element=None):
 		sub_col.scale_y = 1
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_update_now.bl_idname,
-					text="Update directly to " + str(updater.include_branch_list[0]))
+		split.operator(AddonUpdaterUpdateNow.bl_idname,
+					   text="Update directly to " + str(updater.include_branch_list[0]))
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	elif updater.update_ready and not updater.manual_only:
 		sub_col = col.row(align=True)
 		sub_col.scale_y = 1
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_update_now.bl_idname,
-					text="Update now to "+str(updater.update_version))
+		split.operator(AddonUpdaterUpdateNow.bl_idname,
+					   text="Update now to "+str(updater.update_version))
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	elif updater.update_ready and updater.manual_only:
 		col.scale_y = 2
@@ -1211,12 +1211,12 @@ def update_settings_ui_condensed(self, context, element=None):
 		split = sub_col.split(align=True)
 		split.enabled = False
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="Addon is up to date")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="Addon is up to date")
 		split = sub_col.split(align=True)
 		split.scale_y = 2
-		split.operator(addon_updater_check_now.bl_idname,
-						text="", icon="FILE_REFRESH")
+		split.operator(AddonUpdaterCheckNow.bl_idname,
+					   text="", icon="FILE_REFRESH")
 
 	row = element.row()
 	row.prop(settings, "auto_check_update")
@@ -1311,15 +1311,15 @@ def select_link_function(self, tag):
 # Register, should be run in the register module itself
 # -----------------------------------------------------------------------------
 classes = (
-	addon_updater_install_popup,
-	addon_updater_check_now,
-	addon_updater_update_now,
-	addon_updater_update_target,
-	addon_updater_install_manually,
-	addon_updater_updated_successful,
-	addon_updater_restore_backup,
-	addon_updater_ignore,
-	addon_updater_end_background
+	AddonUpdaterInstallPopup,
+	AddonUpdaterCheckNow,
+	AddonUpdaterUpdateNow,
+	AddonUpdaterUpdateTarget,
+	AddonUpdaterInstallManually,
+	AddonUpdaterUpdatedSuccessful,
+	AddonUpdaterRestoreBackup,
+	AddonUpdaterIgnore,
+	AddonUpdaterEndBackground
 )
 
 

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -220,8 +220,8 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
 
 # User preference check-now operator
 class AddonUpdaterCheckNow(bpy.types.Operator):
-	bl_label = "Check now for "+updater.addon+" update"
-	bl_idname = updater.addon+".updater_check_now"
+	bl_label = "Check now for " + updater.addon + " update"
+	bl_idname = updater.addon + ".updater_check_now"
 	bl_description = "Check now for an update to the {x} addon".format(
 														x=updater.addon)
 	bl_options = {'REGISTER', 'INTERNAL'}
@@ -321,8 +321,8 @@ class AddonUpdaterUpdateNow(bpy.types.Operator):
 
 
 class AddonUpdaterUpdateTarget(bpy.types.Operator):
-	bl_label = updater.addon+" version target"
-	bl_idname = updater.addon+".updater_update_target"
+	bl_label = updater.addon + " version target"
+	bl_idname = updater.addon + ".updater_update_target"
 	bl_description = "Install a targeted version of the {x} addon".format(
 														x=updater.addon)
 	bl_options = {'REGISTER', 'INTERNAL'}
@@ -466,7 +466,7 @@ class AddonUpdaterInstallManually(bpy.types.Operator):
 class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
 	"""Addon in place, popup telling user it completed or what went wrong"""
 	bl_label = "Installation Report"
-	bl_idname = updater.addon+".updater_update_successful"
+	bl_idname = updater.addon + ".updater_update_successful"
 	bl_description = "Update installation response"
 	bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
 
@@ -550,7 +550,7 @@ class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
 class AddonUpdaterRestoreBackup(bpy.types.Operator):
 	"""Restore addon from backup"""
 	bl_label = "Restore backup"
-	bl_idname = updater.addon+".updater_restore_backup"
+	bl_idname = updater.addon + ".updater_restore_backup"
 	bl_description = "Restore addon from backup"
 	bl_options = {'REGISTER', 'INTERNAL'}
 

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -1436,7 +1436,7 @@ def register(bl_info):
 	# a release/tag). Setting has no impact on BitBucket or GitLab repos
 	updater.use_releases = False
 	# note: Releases always have a tag, but a tag may not always be a release
-	# Therefore, setting True above will filter out any non-annoted tags
+	# Therefore, setting True above will filter out any non-annotated tags
 	# note 2: Using this option will also display the release name instead of
 	# just the tag name, bear this in mind given the skip_tag_function filtering above
 

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -74,22 +74,21 @@ updater.addon = "addon_updater_demo"
 # Blender version utils
 # -----------------------------------------------------------------------------
 def make_annotations(cls):
-	"""Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return cls
-	if bpy.app.version < (2, 93, 0):
-		bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
-	else:
-		bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
-	if bl_props:
-		if '__annotations__' not in cls.__dict__:
-			setattr(cls, '__annotations__', {})
-		annotations = cls.__dict__['__annotations__']
-		for k, v in bl_props.items():
-			annotations[k] = v
-			delattr(cls, k)
-	return cls
-
+    """Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return cls
+    if bpy.app.version < (2, 93, 0):
+        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+    else:
+        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
+    if bl_props:
+        if '__annotations__' not in cls.__dict__:
+            setattr(cls, '__annotations__', {})
+        annotations = cls.__dict__['__annotations__']
+        for k, v in bl_props.items():
+            annotations[k] = v
+            delattr(cls, k)
+    return cls
 
 def layout_split(layout, factor=0.0, align=False):
     """Intermediate method for pre and post blender 2.8 split UI function"""

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -1045,7 +1045,7 @@ def update_settings_ui(self, context, element=None):
         split.operator(AddonUpdaterCheckNow.bl_idname,
                        text="", icon="FILE_REFRESH")
 
-    elif updater.update_read and not updater.manual_only:
+    elif updater.update_ready and not updater.manual_only:
         sub_col = col.row(align=True)
         sub_col.scale_y = 1
         split = sub_col.split(align=True)

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -30,37 +30,37 @@ from bpy.app.handlers import persistent
 # updater import, import safely
 # Prevents popups for users with invalid python installs e.g. missing libraries
 try:
-	from .addon_updater import Updater as updater
+    from .addon_updater import Updater as updater
 except Exception as e:
-	print("ERROR INITIALIZING UPDATER")
-	print(str(e))
-	traceback.print_exc()
+    print("ERROR INITIALIZING UPDATER")
+    print(str(e))
+    traceback.print_exc()
 
-	class SingletonUpdaterNone(object):
-		def __init__(self):
-			self.addon = None
-			self.verbose = False
-			self.use_print_traces = True
-			self.invalid_updater = True  # used to distinguish bad install
-			self.error = None
-			self.error_msg = None
-			self.async_checking = None
+    class SingletonUpdaterNone(object):
+        def __init__(self):
+            self.addon = None
+            self.verbose = False
+            self.use_print_traces = True
+            self.invalid_updater = True  # used to distinguish bad install
+            self.error = None
+            self.error_msg = None
+            self.async_checking = None
 
-		def clear_state(self):
-			self.addon = None
-			self.verbose = False
-			self.invalid_updater = True
-			self.error = None
-			self.error_msg = None
-			self.async_checking = None
+        def clear_state(self):
+            self.addon = None
+            self.verbose = False
+            self.invalid_updater = True
+            self.error = None
+            self.error_msg = None
+            self.async_checking = None
 
-		def run_update(self): pass
+        def run_update(self): pass
 
-		def check_for_update(self): pass
+        def check_for_update(self): pass
 
-	updater = SingletonUpdaterNone()
-	updater.error = "Error initializing updater module"
-	updater.error_msg = str(e)
+    updater = SingletonUpdaterNone()
+    updater.error = "Error initializing updater module"
+    updater.error_msg = str(e)
 
 # Must declare this before classes are loaded
 # otherwise the bl_idname's will not match and have errors.
@@ -72,41 +72,41 @@ updater.addon = "addon_updater_demo"
 # Blender version utils
 # -----------------------------------------------------------------------------
 def make_annotations(cls):
-	"""Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return cls
-	bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
-	if bl_props:
-		if '__annotations__' not in cls.__dict__:
-			setattr(cls, '__annotations__', {})
-		annotations = cls.__dict__['__annotations__']
-		for k, v in bl_props.items():
-			annotations[k] = v
-			delattr(cls, k)
-	return cls
+    """Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return cls
+    bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+    if bl_props:
+        if '__annotations__' not in cls.__dict__:
+            setattr(cls, '__annotations__', {})
+        annotations = cls.__dict__['__annotations__']
+        for k, v in bl_props.items():
+            annotations[k] = v
+            delattr(cls, k)
+    return cls
 
 
 def layout_split(layout, factor=0.0, align=False):
-	"""Intermediate method for pre and post blender 2.8 split UI function"""
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return layout.split(percentage=factor, align=align)
-	return layout.split(factor=factor, align=align)
+    """Intermediate method for pre and post blender 2.8 split UI function"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return layout.split(percentage=factor, align=align)
+    return layout.split(factor=factor, align=align)
 
 
 def get_user_preferences(context=None):
-	"""Intermediate method for pre and post blender 2.8 grabbing preferences"""
-	if not context:
-		context = bpy.context
-	prefs = None
-	if hasattr(context, "user_preferences"):
-		prefs = context.user_preferences.addons.get(__package__, None)
-	elif hasattr(context, "preferences"):
-		prefs = context.preferences.addons.get(__package__, None)
-	if prefs:
-		return prefs.preferences
-	# To make the addon stable and non-exception prone, return None
-	# raise Exception("Could not fetch user preferences")
-	return None
+    """Intermediate method for pre and post blender 2.8 grabbing preferences"""
+    if not context:
+        context = bpy.context
+    prefs = None
+    if hasattr(context, "user_preferences"):
+        prefs = context.user_preferences.addons.get(__package__, None)
+    elif hasattr(context, "preferences"):
+        prefs = context.preferences.addons.get(__package__, None)
+    if prefs:
+        return prefs.preferences
+    # To make the addon stable and non-exception prone, return None
+    # raise Exception("Could not fetch user preferences")
+    return None
 
 
 # -----------------------------------------------------------------------------
@@ -116,504 +116,504 @@ def get_user_preferences(context=None):
 
 # simple popup for prompting checking for update & allow to install if available
 class AddonUpdaterInstallPopup(bpy.types.Operator):
-	"""Check and install update if available"""
-	bl_label = "Update {x} addon".format(x=updater.addon)
-	bl_idname = updater.addon+".updater_install_popup"
-	bl_description = "Popup menu to check and display current updates available"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Check and install update if available"""
+    bl_label = "Update {x} addon".format(x=updater.addon)
+    bl_idname = updater.addon+".updater_install_popup"
+    bl_description = "Popup menu to check and display current updates available"
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	# if true, run clean install - ie remove all files before adding new
-	# equivalent to deleting the addon and reinstalling, except the
-	# updater folder/backup folder remains
-	clean_install = bpy.props.BoolProperty(
-		name="Clean install",
-		description="If enabled, completely clear the addon's folder before installing new update, creating a fresh install",
-		default=False,
-		options={'HIDDEN'}
-	)
+    # if true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the
+    # updater folder/backup folder remains
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description="If enabled, completely clear the addon's folder before installing new update, creating a fresh install",
+        default=False,
+        options={'HIDDEN'}
+    )
 
-	ignore_enum = bpy.props.EnumProperty(
-		name="Process update",
-		description="Decide to install, ignore, or defer new addon update",
-		items=[
-			("install", "Update Now", "Install update now"),
-			("ignore", "Ignore", "Ignore this update to prevent future popups"),
-			("defer", "Defer", "Defer choice till next blender session")
-		],
-		options={'HIDDEN'}
-	)
+    ignore_enum = bpy.props.EnumProperty(
+        name="Process update",
+        description="Decide to install, ignore, or defer new addon update",
+        items=[
+            ("install", "Update Now", "Install update now"),
+            ("ignore", "Ignore", "Ignore this update to prevent future popups"),
+            ("defer", "Defer", "Defer choice till next blender session")
+        ],
+        options={'HIDDEN'}
+    )
 
-	def check(self, context):
-		return True
+    def check(self, context):
+        return True
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
 
-	def draw(self, context):
-		layout = self.layout
-		if updater.invalid_updater:
-			layout.label(text="Updater module error")
-			return
-		elif updater.update_ready:
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="Update {} ready!".format(str(updater.update_version)),
-						icon="LOOP_FORWARDS")
-			col.label(text="Choose 'Update Now' & press OK to install, ", icon="BLANK1")
-			col.label(text="or click outside window to defer", icon="BLANK1")
-			row = col.row()
-			row.prop(self, "ignore_enum", expand=True)
-			col.split()
-		elif not updater.update_ready:
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="No updates available")
-			col.label(text="Press okay to dismiss dialog")
-			# add option to force install
-		else:
-			# case: updater.update_ready = None
-			# we have not yet checked for the update
-			layout.label(text="Check for update now?")
+    def draw(self, context):
+        layout = self.layout
+        if updater.invalid_updater:
+            layout.label(text="Updater module error")
+            return
+        elif updater.update_ready:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Update {} ready!".format(str(updater.update_version)),
+                        icon="LOOP_FORWARDS")
+            col.label(text="Choose 'Update Now' & press OK to install, ", icon="BLANK1")
+            col.label(text="or click outside window to defer", icon="BLANK1")
+            row = col.row()
+            row.prop(self, "ignore_enum", expand=True)
+            col.split()
+        elif not updater.update_ready:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="No updates available")
+            col.label(text="Press okay to dismiss dialog")
+            # add option to force install
+        else:
+            # case: updater.update_ready = None
+            # we have not yet checked for the update
+            layout.label(text="Check for update now?")
 
-		# potentially in future, could have UI for 'check to select old version'
-		# to revert back to.
+        # potentially in future, could have UI for 'check to select old version'
+        # to revert back to.
 
-	def execute(self, context):
+    def execute(self, context):
 
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
 
-		if updater.manual_only:
-			bpy.ops.wm.url_open(url=updater.website)
-		elif updater.update_ready:
+        if updater.manual_only:
+            bpy.ops.wm.url_open(url=updater.website)
+        elif updater.update_ready:
 
-			# action based on enum selection
-			if self.ignore_enum == 'defer':
-				return {'FINISHED'}
-			elif self.ignore_enum == 'ignore':
-				updater.ignore_update()
-				return {'FINISHED'}
-			# else: "install update now!"
+            # action based on enum selection
+            if self.ignore_enum == 'defer':
+                return {'FINISHED'}
+            elif self.ignore_enum == 'ignore':
+                updater.ignore_update()
+                return {'FINISHED'}
+            # else: "install update now!"
 
-			res = updater.run_update(force=False,
-									callback=post_update_callback,
-									clean=self.clean_install)
+            res = updater.run_update(force=False,
+                                    callback=post_update_callback,
+                                    clean=self.clean_install)
 
-			# should return 0, if not something happened
-			if updater.verbose:
-				if res == 0:
-					print("Updater returned successful")
-				else:
-					print("Updater returned {}, error occurred".format(res))
-		elif updater.update_ready is None:
-			_ = updater.check_for_update(now=True)
+            # should return 0, if not something happened
+            if updater.verbose:
+                if res == 0:
+                    print("Updater returned successful")
+                else:
+                    print("Updater returned {}, error occurred".format(res))
+        elif updater.update_ready is None:
+            _ = updater.check_for_update(now=True)
 
-			# re-launch this dialog
-			atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-			getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-		else:
-			if updater.verbose:
-				print("Doing nothing, not ready for update")
-		return {'FINISHED'}
+            # re-launch this dialog
+            atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+            getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        else:
+            if updater.verbose:
+                print("Doing nothing, not ready for update")
+        return {'FINISHED'}
 
 
 # User preference check-now operator
 class AddonUpdaterCheckNow(bpy.types.Operator):
-	bl_label = "Check now for " + updater.addon + " update"
-	bl_idname = updater.addon + ".updater_check_now"
-	bl_description = "Check now for an update to the {x} addon".format(
-														x=updater.addon)
-	bl_options = {'REGISTER', 'INTERNAL'}
+    bl_label = "Check now for " + updater.addon + " update"
+    bl_idname = updater.addon + ".updater_check_now"
+    bl_description = "Check now for an update to the {x} addon".format(
+                                                        x=updater.addon)
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	def execute(self, context):
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+    def execute(self, context):
+        if updater.invalid_updater:
+            return {'CANCELLED'}
 
-		if updater.async_checking and updater.error is None:
-			# Check already happened
-			# Used here to just avoid constant applying settings below
-			# Ignoring if error, to prevent being stuck on the error screen
-			return {'CANCELLED'}
+        if updater.async_checking and updater.error is None:
+            # Check already happened
+            # Used here to just avoid constant applying settings below
+            # Ignoring if error, to prevent being stuck on the error screen
+            return {'CANCELLED'}
 
-		# apply the UI settings
-		settings = get_user_preferences(context)
-		if not settings:
-			if updater.verbose:
-				print("Could not get {} preferences, update check skipped".format(
-					__package__))
-			return {'CANCELLED'}
+        # apply the UI settings
+        settings = get_user_preferences(context)
+        if not settings:
+            if updater.verbose:
+                print("Could not get {} preferences, update check skipped".format(
+                    __package__))
+            return {'CANCELLED'}
 
-		updater.set_check_interval(
-			enable=settings.auto_check_update,
-			months=settings.updater_interval_months,
-			days=settings.updater_interval_days,
-			hours=settings.updater_interval_hours,
-			minutes=settings.updater_interval_minutes)  # optional, if auto_check_update
+        updater.set_check_interval(
+            enable=settings.auto_check_update,
+            months=settings.updater_interval_months,
+            days=settings.updater_interval_days,
+            hours=settings.updater_interval_hours,
+            minutes=settings.updater_interval_minutes)  # optional, if auto_check_update
 
-		# input is an optional callback function
-		# this function should take a bool input, if true: update ready
-		# if false, no update ready
-		updater.check_for_update_now(ui_refresh)
+        # input is an optional callback function
+        # this function should take a bool input, if true: update ready
+        # if false, no update ready
+        updater.check_for_update_now(ui_refresh)
 
-		return {'FINISHED'}
+        return {'FINISHED'}
 
 
 class AddonUpdaterUpdateNow(bpy.types.Operator):
-	bl_label = "Update " + updater.addon + " addon now"
-	bl_idname = updater.addon + ".updater_update_now"
-	bl_description = "Update to the latest version of the {x} addon".format(
-														x=updater.addon)
-	bl_options = {'REGISTER', 'INTERNAL'}
+    bl_label = "Update " + updater.addon + " addon now"
+    bl_idname = updater.addon + ".updater_update_now"
+    bl_description = "Update to the latest version of the {x} addon".format(
+                                                        x=updater.addon)
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	# if true, run clean install - ie remove all files before adding new
-	# equivalent to deleting the addon and reinstalling, except the
-	# updater folder/backup folder remains
-	clean_install = bpy.props.BoolProperty(
-		name="Clean install",
-		description="If enabled, completely clear the addon's folder before installing new update, creating a fresh install",
-		default=False,
-		options={'HIDDEN'}
-	)
+    # if true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the
+    # updater folder/backup folder remains
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description="If enabled, completely clear the addon's folder before installing new update, creating a fresh install",
+        default=False,
+        options={'HIDDEN'}
+    )
 
-	def execute(self, context):
+    def execute(self, context):
 
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
 
-		if updater.manual_only:
-			bpy.ops.wm.url_open(url=updater.website)
-		if updater.update_ready:
-			# if it fails, offer to open the website instead
-			try:
-				res = updater.run_update(
-					force=False,
-					callback=post_update_callback,
-					clean=self.clean_install)
+        if updater.manual_only:
+            bpy.ops.wm.url_open(url=updater.website)
+        if updater.update_ready:
+            # if it fails, offer to open the website instead
+            try:
+                res = updater.run_update(
+                    force=False,
+                    callback=post_update_callback,
+                    clean=self.clean_install)
 
-				# should return 0, if not something happened
-				if updater.verbose:
-					if res == 0:
-						print("Updater returned successful")
-					else:
-						print("Updater returned " + str(res) + ", error occurred")
-			except Exception as expt:
-				updater._error = "Error trying to run update"
-				updater._error_msg = str(expt)
-				updater.print_trace()
-				atr = AddonUpdaterInstallManually.bl_idname.split(".")
-				getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-		elif updater.update_ready is None:
-			(update_ready, version, link) = updater.check_for_update(now=True)
-			# re-launch this dialog
-			atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-			getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+                # should return 0, if not something happened
+                if updater.verbose:
+                    if res == 0:
+                        print("Updater returned successful")
+                    else:
+                        print("Updater returned " + str(res) + ", error occurred")
+            except Exception as expt:
+                updater._error = "Error trying to run update"
+                updater._error_msg = str(expt)
+                updater.print_trace()
+                atr = AddonUpdaterInstallManually.bl_idname.split(".")
+                getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        elif updater.update_ready is None:
+            (update_ready, version, link) = updater.check_for_update(now=True)
+            # re-launch this dialog
+            atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+            getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 
-		elif not updater.update_ready:
-			self.report({'INFO'}, "Nothing to update")
-			return {'CANCELLED'}
-		else:
-			self.report({'ERROR'}, "Encountered problem while trying to update")
-			return {'CANCELLED'}
+        elif not updater.update_ready:
+            self.report({'INFO'}, "Nothing to update")
+            return {'CANCELLED'}
+        else:
+            self.report({'ERROR'}, "Encountered problem while trying to update")
+            return {'CANCELLED'}
 
-		return {'FINISHED'}
+        return {'FINISHED'}
 
 
 class AddonUpdaterUpdateTarget(bpy.types.Operator):
-	bl_label = updater.addon + " version target"
-	bl_idname = updater.addon + ".updater_update_target"
-	bl_description = "Install a targeted version of the {x} addon".format(
-														x=updater.addon)
-	bl_options = {'REGISTER', 'INTERNAL'}
+    bl_label = updater.addon + " version target"
+    bl_idname = updater.addon + ".updater_update_target"
+    bl_description = "Install a targeted version of the {x} addon".format(
+                                                        x=updater.addon)
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	def target_version(self, context):
-		# in case of error importing updater
-		if updater.invalid_updater:
-			ret = []
+    def target_version(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            ret = []
 
-		ret = []
-		i = 0
-		for tag in updater.tags:
-			ret.append((tag, tag, "Select to install " + tag))
-			i += 1
-		return ret
+        ret = []
+        i = 0
+        for tag in updater.tags:
+            ret.append((tag, tag, "Select to install " + tag))
+            i += 1
+        return ret
 
-	target = bpy.props.EnumProperty(
-		name="Target version to install",
-		description="Select the version to install",
-		items=target_version
-	)
+    target = bpy.props.EnumProperty(
+        name="Target version to install",
+        description="Select the version to install",
+        items=target_version
+    )
 
-	# if true, run clean install - ie remove all files before adding new
-	# equivalent to deleting the addon and reinstalling, except the
-	# updater folder/backup folder remains
-	clean_install = bpy.props.BoolProperty(
-		name="Clean install",
-		description="If enabled, completely clear the addon's folder before installing new update, creating a fresh install",
-		default=False,
-		options={'HIDDEN'}
-	)
+    # if true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the
+    # updater folder/backup folder remains
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description="If enabled, completely clear the addon's folder before installing new update, creating a fresh install",
+        default=False,
+        options={'HIDDEN'}
+    )
 
-	@classmethod
-	def poll(cls, context):
-		if updater.invalid_updater:
-			return False
-		return updater.update_ready is not None and len(updater.tags) > 0
+    @classmethod
+    def poll(cls, context):
+        if updater.invalid_updater:
+            return False
+        return updater.update_ready is not None and len(updater.tags) > 0
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
 
-	def draw(self, context):
-		layout = self.layout
-		if updater.invalid_updater:
-			layout.label(text="Updater error")
-			return
-		split = layout_split(layout, factor=0.5)
-		sub_col = split.column()
-		sub_col.label(text="Select install version")
-		sub_col = split.column()
-		sub_col.prop(self, "target", text="")
+    def draw(self, context):
+        layout = self.layout
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
+        split = layout_split(layout, factor=0.5)
+        sub_col = split.column()
+        sub_col.label(text="Select install version")
+        sub_col = split.column()
+        sub_col.prop(self, "target", text="")
 
-	def execute(self, context):
+    def execute(self, context):
 
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
 
-		res = updater.run_update(
-			force=False,
-			revert_tag=self.target,
-			callback=post_update_callback,
-			clean=self.clean_install)
+        res = updater.run_update(
+            force=False,
+            revert_tag=self.target,
+            callback=post_update_callback,
+            clean=self.clean_install)
 
-		# should return 0, if not something happened
-		if res == 0:
-			if updater.verbose:
-				print("Updater returned successful")
-		else:
-			if updater.verbose:
-				print("Updater returned " + str(res) + ", error occurred")
-			return {'CANCELLED'}
+        # should return 0, if not something happened
+        if res == 0:
+            if updater.verbose:
+                print("Updater returned successful")
+        else:
+            if updater.verbose:
+                print("Updater returned " + str(res) + ", error occurred")
+            return {'CANCELLED'}
 
-		return {'FINISHED'}
+        return {'FINISHED'}
 
 
 class AddonUpdaterInstallManually(bpy.types.Operator):
-	"""As a fallback, direct the user to download the addon manually"""
-	bl_label = "Install update manually"
-	bl_idname = updater.addon + ".updater_install_manually"
-	bl_description = "Proceed to manually install update"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """As a fallback, direct the user to download the addon manually"""
+    bl_label = "Install update manually"
+    bl_idname = updater.addon + ".updater_install_manually"
+    bl_description = "Proceed to manually install update"
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	error = bpy.props.StringProperty(
-		name="Error Occurred",
-		default="",
-		options={'HIDDEN'}
-	)
+    error = bpy.props.StringProperty(
+        name="Error Occurred",
+        default="",
+        options={'HIDDEN'}
+    )
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_popup(self)
+    def invoke(self, context, event):
+        return context.window_manager.invoke_popup(self)
 
-	def draw(self, context):
-		layout = self.layout
+    def draw(self, context):
+        layout = self.layout
 
-		if updater.invalid_updater:
-			layout.label(text="Updater error")
-			return
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
 
-		# use a "failed flag"? it shows this label if the case failed.
-		if self.error is not "":
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="There was an issue trying to auto-install", icon="ERROR")
-			col.label(text="Press the download button below and install", icon="BLANK1")
-			col.label(text="the zip file like a normal addon.", icon="BLANK1")
-		else:
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="Install the addon manually")
-			col.label(text="Press the download button below and install")
-			col.label(text="the zip file like a normal addon.")
+        # use a "failed flag"? it shows this label if the case failed.
+        if self.error is not "":
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="There was an issue trying to auto-install", icon="ERROR")
+            col.label(text="Press the download button below and install", icon="BLANK1")
+            col.label(text="the zip file like a normal addon.", icon="BLANK1")
+        else:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Install the addon manually")
+            col.label(text="Press the download button below and install")
+            col.label(text="the zip file like a normal addon.")
 
-		# if check hasn't happened, i.e. accidentally called this menu
-		# allow to check here
+        # if check hasn't happened, i.e. accidentally called this menu
+        # allow to check here
 
-		row = layout.row()
+        row = layout.row()
 
-		if updater.update_link is not None:
-			row.operator(
-				"wm.url_open",
-				text="Direct download").url = updater.update_link
-		else:
-			row.operator(
-				"wm.url_open",
-				text="(failed to retrieve direct download)")
-			row.enabled = False
+        if updater.update_link is not None:
+            row.operator(
+                "wm.url_open",
+                text="Direct download").url = updater.update_link
+        else:
+            row.operator(
+                "wm.url_open",
+                text="(failed to retrieve direct download)")
+            row.enabled = False
 
-			if updater.website is not None:
-				row = layout.row()
-				row.operator("wm.url_open",
-				text="Open website").url = updater.website
-			else:
-				row = layout.row()
-				row.label(text="See source website to download the update")
+            if updater.website is not None:
+                row = layout.row()
+                row.operator("wm.url_open",
+                text="Open website").url = updater.website
+            else:
+                row = layout.row()
+                row.label(text="See source website to download the update")
 
-	def execute(self, context):
-		return {'FINISHED'}
+    def execute(self, context):
+        return {'FINISHED'}
 
 
 class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
-	"""Addon in place, popup telling user it completed or what went wrong"""
-	bl_label = "Installation Report"
-	bl_idname = updater.addon + ".updater_update_successful"
-	bl_description = "Update installation response"
-	bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
+    """Addon in place, popup telling user it completed or what went wrong"""
+    bl_label = "Installation Report"
+    bl_idname = updater.addon + ".updater_update_successful"
+    bl_description = "Update installation response"
+    bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
 
-	error = bpy.props.StringProperty(
-		name="Error Occurred",
-		default="",
-		options={'HIDDEN'}
-	)
+    error = bpy.props.StringProperty(
+        name="Error Occurred",
+        default="",
+        options={'HIDDEN'}
+    )
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_popup(self, event)
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_popup(self, event)
 
-	def draw(self, context):
-		layout = self.layout
+    def draw(self, context):
+        layout = self.layout
 
-		if updater.invalid_updater:
-			layout.label(text="Updater error")
-			return
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
 
-		saved = updater.json
-		if self.error != "":
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="Error occurred, did not install", icon="ERROR")
-			if updater.error_msg:
-				msg = updater.error_msg
-			else:
-				msg = self.error
-			col.label(text=str(msg), icon="BLANK1")
-			rw = col.row()
-			rw.scale_y = 2
-			rw.operator(
-				"wm.url_open",
-				text="Click for manual download.",
-				icon="BLANK1").url = updater.website
-			# manual download button here
-		elif not updater.auto_reload_post_update:
-			# tell user to restart blender
-			if "just_restored" in saved and saved["just_restored"]:
-				col = layout.column()
-				col.label(text="Addon restored", icon="RECOVER_LAST")
-				alert_row = col.row()
-				alert_row.alert = True
-				alert_row.operator(
-					"wm.quit_blender",
-					text="Restart blender to reload",
-					icon="BLANK1")
-				updater.json_reset_restore()
-			else:
-				col = layout.column()
-				col.label(text="Addon successfully installed", icon="FILE_TICK")
-				alert_row = col.row()
-				alert_row.alert = True
-				alert_row.operator(
-					"wm.quit_blender",
-					text="Restart blender to reload",
-					icon="BLANK1")
+        saved = updater.json
+        if self.error != "":
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Error occurred, did not install", icon="ERROR")
+            if updater.error_msg:
+                msg = updater.error_msg
+            else:
+                msg = self.error
+            col.label(text=str(msg), icon="BLANK1")
+            rw = col.row()
+            rw.scale_y = 2
+            rw.operator(
+                "wm.url_open",
+                text="Click for manual download.",
+                icon="BLANK1").url = updater.website
+            # manual download button here
+        elif not updater.auto_reload_post_update:
+            # tell user to restart blender
+            if "just_restored" in saved and saved["just_restored"]:
+                col = layout.column()
+                col.label(text="Addon restored", icon="RECOVER_LAST")
+                alert_row = col.row()
+                alert_row.alert = True
+                alert_row.operator(
+                    "wm.quit_blender",
+                    text="Restart blender to reload",
+                    icon="BLANK1")
+                updater.json_reset_restore()
+            else:
+                col = layout.column()
+                col.label(text="Addon successfully installed", icon="FILE_TICK")
+                alert_row = col.row()
+                alert_row.alert = True
+                alert_row.operator(
+                    "wm.quit_blender",
+                    text="Restart blender to reload",
+                    icon="BLANK1")
 
-		else:
-			# reload addon, but still recommend they restart blender
-			if "just_restored" in saved and saved["just_restored"]:
-				col = layout.column()
-				col.scale_y = 0.7
-				col.label(text="Addon restored", icon="RECOVER_LAST")
-				col.label(
-					text="Consider restarting blender to fully reload.",
-					icon="BLANK1")
-				updater.json_reset_restore()
-			else:
-				col = layout.column()
-				col.scale_y = 0.7
-				col.label(text="Addon successfully installed", icon="FILE_TICK")
-				col.label(
-					text="Consider restarting blender to fully reload.",
-					icon="BLANK1")
+        else:
+            # reload addon, but still recommend they restart blender
+            if "just_restored" in saved and saved["just_restored"]:
+                col = layout.column()
+                col.scale_y = 0.7
+                col.label(text="Addon restored", icon="RECOVER_LAST")
+                col.label(
+                    text="Consider restarting blender to fully reload.",
+                    icon="BLANK1")
+                updater.json_reset_restore()
+            else:
+                col = layout.column()
+                col.scale_y = 0.7
+                col.label(text="Addon successfully installed", icon="FILE_TICK")
+                col.label(
+                    text="Consider restarting blender to fully reload.",
+                    icon="BLANK1")
 
-	def execute(self, context):
-		return {'FINISHED'}
+    def execute(self, context):
+        return {'FINISHED'}
 
 
 class AddonUpdaterRestoreBackup(bpy.types.Operator):
-	"""Restore addon from backup"""
-	bl_label = "Restore backup"
-	bl_idname = updater.addon + ".updater_restore_backup"
-	bl_description = "Restore addon from backup"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Restore addon from backup"""
+    bl_label = "Restore backup"
+    bl_idname = updater.addon + ".updater_restore_backup"
+    bl_description = "Restore addon from backup"
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	@classmethod
-	def poll(cls, context):
-		try:
-			return os.path.isdir(os.path.join(updater.stage_path, "backup"))
-		except:
-			return False
+    @classmethod
+    def poll(cls, context):
+        try:
+            return os.path.isdir(os.path.join(updater.stage_path, "backup"))
+        except:
+            return False
 
-	def execute(self, context):
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
-		updater.restore_backup()
-		return {'FINISHED'}
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+        updater.restore_backup()
+        return {'FINISHED'}
 
 
 class AddonUpdaterIgnore(bpy.types.Operator):
-	"""Prevent future update notice popups"""
-	bl_label = "Ignore update"
-	bl_idname = updater.addon + ".updater_ignore"
-	bl_description = "Ignore update to prevent future popups"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Prevent future update notice popups"""
+    bl_label = "Ignore update"
+    bl_idname = updater.addon + ".updater_ignore"
+    bl_description = "Ignore update to prevent future popups"
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	@classmethod
-	def poll(cls, context):
-		if updater.invalid_updater:
-			return False
-		elif updater.update_ready:
-			return True
-		else:
-			return False
+    @classmethod
+    def poll(cls, context):
+        if updater.invalid_updater:
+            return False
+        elif updater.update_ready:
+            return True
+        else:
+            return False
 
-	def execute(self, context):
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
-		updater.ignore_update()
-		self.report({"INFO"}, "Open addon preferences for updater options")
-		return {'FINISHED'}
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+        updater.ignore_update()
+        self.report({"INFO"}, "Open addon preferences for updater options")
+        return {'FINISHED'}
 
 
 class AddonUpdaterEndBackground(bpy.types.Operator):
-	"""Stop checking for update in the background"""
-	bl_label = "End background check"
-	bl_idname = updater.addon + ".end_background_check"
-	bl_description = "Stop checking for update in the background"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Stop checking for update in the background"""
+    bl_label = "End background check"
+    bl_idname = updater.addon + ".end_background_check"
+    bl_description = "Stop checking for update in the background"
+    bl_options = {'REGISTER', 'INTERNAL'}
 
-	# @classmethod
-	# def poll(cls, context):
-	# 	if updater.async_checking == True:
-	# 		return True
-	# 	else:
-	# 		return False
+    # @classmethod
+    # def poll(cls, context):
+    # 	if updater.async_checking == True:
+    # 		return True
+    # 	else:
+    # 		return False
 
-	def execute(self, context):
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
-		updater.stop_async_check_update()
-		return {'FINISHED'}
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {'CANCELLED'}
+        updater.stop_async_check_update()
+        return {'FINISHED'}
 
 
 # -----------------------------------------------------------------------------
@@ -631,890 +631,890 @@ ran_background_check = False
 
 @persistent
 def updater_run_success_popup_handler(scene):
-	global ran_update_success_popup
-	ran_update_success_popup = True
+    global ran_update_success_popup
+    ran_update_success_popup = True
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
 
-	try:
-		if "scene_update_post" in dir(bpy.app.handlers):
-			bpy.app.handlers.scene_update_post.remove(
-					updater_run_success_popup_handler)
-		else:
-			bpy.app.handlers.depsgraph_update_post.remove(
-					updater_run_success_popup_handler)
-	except:
-		pass
+    try:
+        if "scene_update_post" in dir(bpy.app.handlers):
+            bpy.app.handlers.scene_update_post.remove(
+                    updater_run_success_popup_handler)
+        else:
+            bpy.app.handlers.depsgraph_update_post.remove(
+                    updater_run_success_popup_handler)
+    except:
+        pass
 
-	atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
-	getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+    atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+    getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 
 
 @persistent
 def updater_run_install_popup_handler(scene):
-	global ran_auto_check_install_popup
-	ran_auto_check_install_popup = True
+    global ran_auto_check_install_popup
+    ran_auto_check_install_popup = True
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
 
-	try:
-		if "scene_update_post" in dir(bpy.app.handlers):
-			bpy.app.handlers.scene_update_post.remove(
-					updater_run_install_popup_handler)
-		else:
-			bpy.app.handlers.depsgraph_update_post.remove(
-					updater_run_install_popup_handler)
-	except:
-		pass
+    try:
+        if "scene_update_post" in dir(bpy.app.handlers):
+            bpy.app.handlers.scene_update_post.remove(
+                    updater_run_install_popup_handler)
+        else:
+            bpy.app.handlers.depsgraph_update_post.remove(
+                    updater_run_install_popup_handler)
+    except:
+        pass
 
-	if "ignore" in updater.json and updater.json["ignore"]:
-		return  # don't do popup if ignore pressed
-	# elif type(updater.update_version) != type((0,0,0)):
-	# 	# likely was from master or another branch, shouldn't trigger popup
-	# 	updater.json_reset_restore()
-	# 	return
-	elif "version_text" in updater.json and "version" in updater.json["version_text"]:
-		version = updater.json["version_text"]["version"]
-		ver_tuple = updater.version_tuple_from_text(version)
+    if "ignore" in updater.json and updater.json["ignore"]:
+        return  # don't do popup if ignore pressed
+    # elif type(updater.update_version) != type((0,0,0)):
+    # 	# likely was from master or another branch, shouldn't trigger popup
+    # 	updater.json_reset_restore()
+    # 	return
+    elif "version_text" in updater.json and "version" in updater.json["version_text"]:
+        version = updater.json["version_text"]["version"]
+        ver_tuple = updater.version_tuple_from_text(version)
 
-		if ver_tuple < updater.current_version:
-			# user probably manually installed to get the up to date addon
-			# in here. Clear out the update flag using this function
-			if updater.verbose:
-				print("{} updater: appears user updated, clearing flag".format(
-						updater.addon))
-			updater.json_reset_restore()
-			return
-	atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-	getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        if ver_tuple < updater.current_version:
+            # user probably manually installed to get the up to date addon
+            # in here. Clear out the update flag using this function
+            if updater.verbose:
+                print("{} updater: appears user updated, clearing flag".format(
+                        updater.addon))
+            updater.json_reset_restore()
+            return
+    atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+    getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
 
 
 def background_update_callback(update_ready):
-	"""Passed into the updater, background thread updater"""
-	global ran_auto_check_install_popup
+    """Passed into the updater, background thread updater"""
+    global ran_auto_check_install_popup
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		return
-	if not updater.showpopups:
-		return
-	if not update_ready:
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
+    if not updater.showpopups:
+        return
+    if not update_ready:
+        return
 
-	# see if we need add to the update handler to trigger the popup
-	handlers = []
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		handlers = bpy.app.handlers.scene_update_post
-	else:  # 2.8x
-		handlers = bpy.app.handlers.depsgraph_update_post
-	in_handles = updater_run_install_popup_handler in handlers
+    # see if we need add to the update handler to trigger the popup
+    handlers = []
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        handlers = bpy.app.handlers.scene_update_post
+    else:  # 2.8x
+        handlers = bpy.app.handlers.depsgraph_update_post
+    in_handles = updater_run_install_popup_handler in handlers
 
-	if in_handles or ran_auto_check_install_popup:
-		return
+    if in_handles or ran_auto_check_install_popup:
+        return
 
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		bpy.app.handlers.scene_update_post.append(
-				updater_run_install_popup_handler)
-	else:  # 2.8x
-		bpy.app.handlers.depsgraph_update_post.append(
-				updater_run_install_popup_handler)
-	ran_auto_check_install_popup = True
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        bpy.app.handlers.scene_update_post.append(
+                updater_run_install_popup_handler)
+    else:  # 2.8x
+        bpy.app.handlers.depsgraph_update_post.append(
+                updater_run_install_popup_handler)
+    ran_auto_check_install_popup = True
 
 
 def post_update_callback(module_name, res=None):
-	"""Callback for once the run_update function has completed
+    """Callback for once the run_update function has completed
 
-	Only makes sense to use this if "auto_reload_post_update" == False,
-	i.e. don't auto-restart the addon
+    Only makes sense to use this if "auto_reload_post_update" == False,
+    i.e. don't auto-restart the addon
 
-	Arguments:
-		module_name: returns the module name from updater, but unused here
-		res: If an error occurred, this is the detail string
-	"""
+    Arguments:
+        module_name: returns the module name from updater, but unused here
+        res: If an error occurred, this is the detail string
+    """
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
 
-	if res is None:
-		# this is the same code as in conditional at the end of the register function
-		# ie if "auto_reload_post_update" == True, comment out this code
-		if updater.verbose:
-			print("{} updater: Running post update callback".format(updater.addon))
+    if res is None:
+        # this is the same code as in conditional at the end of the register function
+        # ie if "auto_reload_post_update" == True, comment out this code
+        if updater.verbose:
+            print("{} updater: Running post update callback".format(updater.addon))
 
-		atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
-		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-		global ran_update_success_popup
-		ran_update_success_popup = True
-	else:
-		# some kind of error occurred and it was unable to install,
-		# offer manual download instead
-		atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
-		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT', error=res)
-	return
+        atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        global ran_update_success_popup
+        ran_update_success_popup = True
+    else:
+        # some kind of error occurred and it was unable to install,
+        # offer manual download instead
+        atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT', error=res)
+    return
 
 
 def ui_refresh(update_status):
-	# find a way to just re-draw self?
-	# callback intended for trigger by async thread
-	for windowManager in bpy.data.window_managers:
-		for window in windowManager.windows:
-			for area in window.screen.areas:
-				area.tag_redraw()
+    # find a way to just re-draw self?
+    # callback intended for trigger by async thread
+    for windowManager in bpy.data.window_managers:
+        for window in windowManager.windows:
+            for area in window.screen.areas:
+                area.tag_redraw()
 
 
 def check_for_update_background():
-	"""Function for asynchronous background check.
+    """Function for asynchronous background check.
 
-	*Could* be called on register, but would be bad practice.
-	"""
-	if updater.invalid_updater:
-		return
-	global ran_background_check
-	if ran_background_check:
-		# Global var ensures check only happens once
-		return
-	elif updater.update_ready is not None or updater.async_checking:
-		# Check already happened
-		# Used here to just avoid constant applying settings below
-		return
+    *Could* be called on register, but would be bad practice.
+    """
+    if updater.invalid_updater:
+        return
+    global ran_background_check
+    if ran_background_check:
+        # Global var ensures check only happens once
+        return
+    elif updater.update_ready is not None or updater.async_checking:
+        # Check already happened
+        # Used here to just avoid constant applying settings below
+        return
 
-	# apply the UI settings
-	settings = get_user_preferences(bpy.context)
-	if not settings:
-		return
-	updater.set_check_interval(enable=settings.auto_check_update,
-				months=settings.updater_intrval_months,
-				days=settings.updater_intrval_days,
-				hours=settings.updater_intrval_hours,
-				minutes=settings.updater_intrval_minutes
-				)  # optional, if auto_check_update
+    # apply the UI settings
+    settings = get_user_preferences(bpy.context)
+    if not settings:
+        return
+    updater.set_check_interval(enable=settings.auto_check_update,
+                months=settings.updater_intrval_months,
+                days=settings.updater_intrval_days,
+                hours=settings.updater_intrval_hours,
+                minutes=settings.updater_intrval_minutes
+                )  # optional, if auto_check_update
 
-	# input is an optional callback function
-	# this function should take a bool input, if true: update ready
-	# if false, no update ready
-	if updater.verbose:
-		print("{} updater: Running background check for update".format(
-				updater.addon))
-	updater.check_for_update_async(background_update_callback)
-	ran_background_check = True
+    # input is an optional callback function
+    # this function should take a bool input, if true: update ready
+    # if false, no update ready
+    if updater.verbose:
+        print("{} updater: Running background check for update".format(
+                updater.addon))
+    updater.check_for_update_async(background_update_callback)
+    ran_background_check = True
 
 
 def check_for_update_nonthreaded(self, context):
-	"""Can be placed in front of other operators to launch when pressed"""
-	if updater.invalid_updater:
-		return
+    """Can be placed in front of other operators to launch when pressed"""
+    if updater.invalid_updater:
+        return
 
-	# only check if it's ready, ie after the time interval specified
-	# should be the async wrapper call here
-	settings = get_user_preferences(bpy.context)
-	if not settings:
-		if updater.verbose:
-			print("Could not get {} preferences, update check skipped".format(
-				__package__))
-		return
-	updater.set_check_interval(enable=settings.auto_check_update,
-				months=settings.updater_intrval_months,
-				days=settings.updater_intrval_days,
-				hours=settings.updater_intrval_hours,
-				minutes=settings.updater_intrval_minutes)  # optional, if auto_check_update
+    # only check if it's ready, ie after the time interval specified
+    # should be the async wrapper call here
+    settings = get_user_preferences(bpy.context)
+    if not settings:
+        if updater.verbose:
+            print("Could not get {} preferences, update check skipped".format(
+                __package__))
+        return
+    updater.set_check_interval(enable=settings.auto_check_update,
+                months=settings.updater_intrval_months,
+                days=settings.updater_intrval_days,
+                hours=settings.updater_intrval_hours,
+                minutes=settings.updater_intrval_minutes)  # optional, if auto_check_update
 
-	(update_ready, version, link) = updater.check_for_update(now=False)
-	if update_ready:
-		atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-	else:
-		if updater.verbose:
-			print("No update ready")
-		self.report({'INFO'}, "No update ready")
+    (update_ready, version, link) = updater.check_for_update(now=False)
+    if update_ready:
+        atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+    else:
+        if updater.verbose:
+            print("No update ready")
+        self.report({'INFO'}, "No update ready")
 
 
 def show_reload_popup():
-	"""For use in register only, to show popup after re-enabling the addon
+    """For use in register only, to show popup after re-enabling the addon
 
-	Must be enabled by developer
-	"""
-	if updater.invalid_updater:
-		return
-	saved_state = updater.json
-	global ran_update_success_popup
+    Must be enabled by developer
+    """
+    if updater.invalid_updater:
+        return
+    saved_state = updater.json
+    global ran_update_success_popup
 
-	has_state = saved_state is not None
-	just_updated = "just_updated" in saved_state
-	updated_info = saved_state["just_updated"]
+    has_state = saved_state is not None
+    just_updated = "just_updated" in saved_state
+    updated_info = saved_state["just_updated"]
 
-	if not (has_state and just_updated and updated_info):
-		return
+    if not (has_state and just_updated and updated_info):
+        return
 
-	updater.json_reset_postupdate()  # so this only runs once
+    updater.json_reset_postupdate()  # so this only runs once
 
-	# no handlers in this case
-	if not updater.auto_reload_post_update:
-		return
+    # no handlers in this case
+    if not updater.auto_reload_post_update:
+        return
 
-	# see if we need add to the update handler to trigger the popup
-	handlers = []
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		handlers = bpy.app.handlers.scene_update_post
-	else:  # 2.8x
-		handlers = bpy.app.handlers.depsgraph_update_post
-	in_handles = updater_run_success_popup_handler in handlers
+    # see if we need add to the update handler to trigger the popup
+    handlers = []
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        handlers = bpy.app.handlers.scene_update_post
+    else:  # 2.8x
+        handlers = bpy.app.handlers.depsgraph_update_post
+    in_handles = updater_run_success_popup_handler in handlers
 
-	if in_handles or ran_update_success_popup:
-		return
+    if in_handles or ran_update_success_popup:
+        return
 
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		bpy.app.handlers.scene_update_post.append(
-				updater_run_success_popup_handler)
-	else:  # 2.8x
-		bpy.app.handlers.depsgraph_update_post.append(
-				updater_run_success_popup_handler)
-	ran_update_success_popup = True
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        bpy.app.handlers.scene_update_post.append(
+                updater_run_success_popup_handler)
+    else:  # 2.8x
+        bpy.app.handlers.depsgraph_update_post.append(
+                updater_run_success_popup_handler)
+    ran_update_success_popup = True
 
 
 # -----------------------------------------------------------------------------
 # Example UI integrations
 # -----------------------------------------------------------------------------
 def update_notice_box_ui(self, context):
-	""" Panel - Update Available for placement at end/beginning of panel
+    """ Panel - Update Available for placement at end/beginning of panel
 
-	After a check for update has occurred, this function will draw a box
-	saying an update is ready, and give a button for: update now, open website,
-	or ignore popup. Ideal to be placed at the end / beginning of a panel
-	"""
+    After a check for update has occurred, this function will draw a box
+    saying an update is ready, and give a button for: update now, open website,
+    or ignore popup. Ideal to be placed at the end / beginning of a panel
+    """
 
-	if updater.invalid_updater:
-		return
+    if updater.invalid_updater:
+        return
 
-	saved_state = updater.json
-	if not updater.auto_reload_post_update:
-		if "just_updated" in saved_state and saved_state["just_updated"]:
-			layout = self.layout
-			box = layout.box()
-			col = box.column()
-			alert_row = col.row()
-			alert_row.alert = True
-			alert_row.operator(
-				"wm.quit_blender",
-				text="Restart blender",
-				icon="ERROR")
-			col.label(text="to complete update")
+    saved_state = updater.json
+    if not updater.auto_reload_post_update:
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            layout = self.layout
+            box = layout.box()
+            col = box.column()
+            alert_row = col.row()
+            alert_row.alert = True
+            alert_row.operator(
+                "wm.quit_blender",
+                text="Restart blender",
+                icon="ERROR")
+            col.label(text="to complete update")
 
-			return
+            return
 
-	# if user pressed ignore, don't draw the box
-	if "ignore" in updater.json and updater.json["ignore"]:
-		return
-	if not updater.update_ready:
-		return
+    # if user pressed ignore, don't draw the box
+    if "ignore" in updater.json and updater.json["ignore"]:
+        return
+    if not updater.update_ready:
+        return
 
-	layout = self.layout
-	box = layout.box()
-	col = box.column(align=True)
-	col.label(text="Update ready!", icon="ERROR")
-	col.separator()
-	row = col.row(align=True)
-	split = row.split(align=True)
-	colL = split.column(align=True)
-	colL.scale_y = 1.5
-	colL.operator(AddonUpdaterIgnore.bl_idname, icon="X", text="Ignore")
-	colR = split.column(align=True)
-	colR.scale_y = 1.5
-	if not updater.manual_only:
-		colR.operator(AddonUpdaterUpdateNow.bl_idname,
-					  text="Update", icon="LOOP_FORWARDS")
-		col.operator("wm.url_open", text="Open website").url = updater.website
-		# col.operator("wm.url_open",text="Direct download").url=updater.update_link
-		col.operator(AddonUpdaterInstallManually.bl_idname,
-					 text="Install manually")
-	else:
-		# col.operator("wm.url_open",text="Direct download").url=updater.update_link
-		col.operator("wm.url_open", text="Get it now").url = updater.website
+    layout = self.layout
+    box = layout.box()
+    col = box.column(align=True)
+    col.label(text="Update ready!", icon="ERROR")
+    col.separator()
+    row = col.row(align=True)
+    split = row.split(align=True)
+    colL = split.column(align=True)
+    colL.scale_y = 1.5
+    colL.operator(AddonUpdaterIgnore.bl_idname, icon="X", text="Ignore")
+    colR = split.column(align=True)
+    colR.scale_y = 1.5
+    if not updater.manual_only:
+        colR.operator(AddonUpdaterUpdateNow.bl_idname,
+                      text="Update", icon="LOOP_FORWARDS")
+        col.operator("wm.url_open", text="Open website").url = updater.website
+        # col.operator("wm.url_open",text="Direct download").url=updater.update_link
+        col.operator(AddonUpdaterInstallManually.bl_idname,
+                     text="Install manually")
+    else:
+        # col.operator("wm.url_open",text="Direct download").url=updater.update_link
+        col.operator("wm.url_open", text="Get it now").url = updater.website
 
 
 def update_settings_ui(self, context, element=None):
-	"""Preferences - for drawing with full width inside user preferences
+    """Preferences - for drawing with full width inside user preferences
 
-	Create a function that can be run inside user preferences panel for prefs UI
-	Place inside UI draw using: addon_updater_ops.updaterSettingsUI(self, context)
-	or by: addon_updater_ops.updaterSettingsUI(context)
-	"""
+    Create a function that can be run inside user preferences panel for prefs UI
+    Place inside UI draw using: addon_updater_ops.updaterSettingsUI(self, context)
+    or by: addon_updater_ops.updaterSettingsUI(context)
+    """
 
-	# element is a UI element, such as layout, a row, column, or box
-	if element is None:
-		element = self.layout
-	box = element.box()
+    # element is a UI element, such as layout, a row, column, or box
+    if element is None:
+        element = self.layout
+    box = element.box()
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		box.label(text="Error initializing updater code:")
-		box.label(text=updater.error_msg)
-		return
-	settings = get_user_preferences(context)
-	if not settings:
-		box.label(text="Error getting updater preferences", icon='ERROR')
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        box.label(text="Error initializing updater code:")
+        box.label(text=updater.error_msg)
+        return
+    settings = get_user_preferences(context)
+    if not settings:
+        box.label(text="Error getting updater preferences", icon='ERROR')
+        return
 
-	# auto-update settings
-	box.label(text="Updater Settings")
-	row = box.row()
+    # auto-update settings
+    box.label(text="Updater Settings")
+    row = box.row()
 
-	# special case to tell user to restart blender, if set that way
-	if not updater.auto_reload_post_update:
-		saved_state = updater.json
-		if "just_updated" in saved_state and saved_state["just_updated"]:
-			row.alert = True
-			row.operator(
-				"wm.quit_blender",
-				text="Restart blender to complete update",
-				icon="ERROR")
-			return
+    # special case to tell user to restart blender, if set that way
+    if not updater.auto_reload_post_update:
+        saved_state = updater.json
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            row.alert = True
+            row.operator(
+                "wm.quit_blender",
+                text="Restart blender to complete update",
+                icon="ERROR")
+            return
 
-	split = layout_split(row, factor=0.4)
-	sub_col = split.column()
-	sub_col.prop(settings, "auto_check_update")
-	sub_col = split.column()
+    split = layout_split(row, factor=0.4)
+    sub_col = split.column()
+    sub_col.prop(settings, "auto_check_update")
+    sub_col = split.column()
 
-	if not settings.auto_check_update:
-		sub_col.enabled = False
-	sub_row = sub_col.row()
-	sub_row.label(text="Interval between checks")
-	sub_row = sub_col.row(align=True)
-	check_col = sub_row.column(align=True)
-	check_col.prop(settings, "updater_interval_months")
-	check_col = sub_row.column(align=True)
-	check_col.prop(settings, "updater_interval_days")
-	check_col = sub_row.column(align=True)
+    if not settings.auto_check_update:
+        sub_col.enabled = False
+    sub_row = sub_col.row()
+    sub_row.label(text="Interval between checks")
+    sub_row = sub_col.row(align=True)
+    check_col = sub_row.column(align=True)
+    check_col.prop(settings, "updater_interval_months")
+    check_col = sub_row.column(align=True)
+    check_col.prop(settings, "updater_interval_days")
+    check_col = sub_row.column(align=True)
 
-	# Consider un-commenting for local dev (e.g. to set shorter intervals)
-	# check_col.prop(settings,"updater_interval_hours")
-	# check_col = sub_row.column(align=True)
-	# check_col.prop(settings,"updater_interval_minutes")
+    # Consider un-commenting for local dev (e.g. to set shorter intervals)
+    # check_col.prop(settings,"updater_interval_hours")
+    # check_col = sub_row.column(align=True)
+    # check_col.prop(settings,"updater_interval_minutes")
 
-	# checking / managing updates
-	row = box.row()
-	col = row.column()
-	if updater.error is not None:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		if "ssl" in updater.error_msg.lower():
-			split.enabled = True
-			split.operator(AddonUpdaterInstallManually.bl_idname,
-						   text=updater.error)
-		else:
-			split.enabled = False
-			split.operator(AddonUpdaterCheckNow.bl_idname,
-						   text=updater.error)
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    # checking / managing updates
+    row = box.row()
+    col = row.column()
+    if updater.error is not None:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        if "ssl" in updater.error_msg.lower():
+            split.enabled = True
+            split.operator(AddonUpdaterInstallManually.bl_idname,
+                           text=updater.error)
+        else:
+            split.enabled = False
+            split.operator(AddonUpdaterCheckNow.bl_idname,
+                           text=updater.error)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready is None and not updater.async_checking:
-		col.scale_y = 2
-		col.operator(AddonUpdaterCheckNow.bl_idname)
-	elif updater.update_ready is None:  # async is running
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="Checking...")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterEndBackground.bl_idname,
-					   text="", icon="X")
+    elif updater.update_ready is None and not updater.async_checking:
+        col.scale_y = 2
+        col.operator(AddonUpdaterCheckNow.bl_idname)
+    elif updater.update_ready is None:  # async is running
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="Checking...")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterEndBackground.bl_idname,
+                       text="", icon="X")
 
-	elif updater.include_branches and \
-			len(updater.tags) == len(updater.include_branch_list) and not \
-			updater.manual_only:
-		# no releases found, but still show the appropriate branch
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update directly to " + str(updater.include_branch_list[0]))
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.include_branches and \
+            len(updater.tags) == len(updater.include_branch_list) and not \
+            updater.manual_only:
+        # no releases found, but still show the appropriate branch
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterUpdateNow.bl_idname,
+                       text="Update directly to " + str(updater.include_branch_list[0]))
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	elif updater.update_read and not updater.manual_only:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update now to " + str(updater.update_version))
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_read and not updater.manual_only:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterUpdateNow.bl_idname,
+                       text="Update now to " + str(updater.update_version))
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready and updater.manual_only:
-		col.scale_y = 2
-		col.operator("wm.url_open",
-				text="Download " + str(updater.update_version)).url = updater.website
-	else:  # i.e. that updater.update_ready == False
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="Addon is up to date")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_ready and updater.manual_only:
+        col.scale_y = 2
+        col.operator("wm.url_open",
+                text="Download " + str(updater.update_version)).url = updater.website
+    else:  # i.e. that updater.update_ready == False
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="Addon is up to date")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	if not updater.manual_only:
-		col = row.column(align=True)
-		# col.operator(AddonUpdaterUpdateTarget.bl_idname,
-		if updater.include_branches and len(updater.include_branch_list) > 0:
-			branch = updater.include_branch_list[0]
-			col.operator(AddonUpdaterUpdateTarget.bl_idname,
-						 text="Install latest {} / old version".format(branch))
-		else:
-			col.operator(AddonUpdaterUpdateTarget.bl_idname,
-						 text="Reinstall / install old version")
-		last_date = "none found"
-		backup_path = os.path.join(updater.stage_path, "backup")
-		if "backup_date" in updater.json and os.path.isdir(backup_path):
-			if updater.json["backup_date"] == "":
-				last_date = "Date not found"
-			else:
-				last_date = updater.json["backup_date"]
-		backup_text = "Restore addon backup ({})".format(last_date)
-		col.operator(AddonUpdaterRestoreBackup.bl_idname, text=backup_text)
+    if not updater.manual_only:
+        col = row.column(align=True)
+        # col.operator(AddonUpdaterUpdateTarget.bl_idname,
+        if updater.include_branches and len(updater.include_branch_list) > 0:
+            branch = updater.include_branch_list[0]
+            col.operator(AddonUpdaterUpdateTarget.bl_idname,
+                         text="Install latest {} / old version".format(branch))
+        else:
+            col.operator(AddonUpdaterUpdateTarget.bl_idname,
+                         text="Reinstall / install old version")
+        last_date = "none found"
+        backup_path = os.path.join(updater.stage_path, "backup")
+        if "backup_date" in updater.json and os.path.isdir(backup_path):
+            if updater.json["backup_date"] == "":
+                last_date = "Date not found"
+            else:
+                last_date = updater.json["backup_date"]
+        backup_text = "Restore addon backup ({})".format(last_date)
+        col.operator(AddonUpdaterRestoreBackup.bl_idname, text=backup_text)
 
-	row = box.row()
-	row.scale_y = 0.7
-	last_check = updater.json["last_check"]
-	if updater.error is not None and updater.error_msg is not None:
-		row.label(text=updater.error_msg)
-	elif last_check is not "" and last_check is not None:
-		last_check = last_check[0: last_check.index(".")]
-		row.label(text="Last update check: " + last_check)
-	else:
-		row.label(text="Last update check: Never")
+    row = box.row()
+    row.scale_y = 0.7
+    last_check = updater.json["last_check"]
+    if updater.error is not None and updater.error_msg is not None:
+        row.label(text=updater.error_msg)
+    elif last_check is not "" and last_check is not None:
+        last_check = last_check[0: last_check.index(".")]
+        row.label(text="Last update check: " + last_check)
+    else:
+        row.label(text="Last update check: Never")
 
 
 def update_settings_ui_condensed(self, context, element=None):
-	"""Preferences - Condensed drawing within preferences
+    """Preferences - Condensed drawing within preferences
 
-	Alternate draw for user preferences or other places, does not draw a box
-	"""
+    Alternate draw for user preferences or other places, does not draw a box
+    """
 
-	# element is a UI element, such as layout, a row, column, or box
-	if element is None:
-		element = self.layout
-	row = element.row()
+    # element is a UI element, such as layout, a row, column, or box
+    if element is None:
+        element = self.layout
+    row = element.row()
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		row.label(text="Error initializing updater code:")
-		row.label(text=updater.error_msg)
-		return
-	settings = get_user_preferences(context)
-	if not settings:
-		row.label(text="Error getting updater preferences", icon='ERROR')
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        row.label(text="Error initializing updater code:")
+        row.label(text=updater.error_msg)
+        return
+    settings = get_user_preferences(context)
+    if not settings:
+        row.label(text="Error getting updater preferences", icon='ERROR')
+        return
 
-	# special case to tell user to restart blender, if set that way
-	if not updater.auto_reload_post_update:
-		saved_state = updater.json
-		if "just_updated" in saved_state and saved_state["just_updated"]:
-			row.alert = True  # mark red
-			row.operator(
-				"wm.quit_blender",
-				text="Restart blender to complete update",
-				icon="ERROR")
-			return
+    # special case to tell user to restart blender, if set that way
+    if not updater.auto_reload_post_update:
+        saved_state = updater.json
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            row.alert = True  # mark red
+            row.operator(
+                "wm.quit_blender",
+                text="Restart blender to complete update",
+                icon="ERROR")
+            return
 
-	col = row.column()
-	if updater.error is not None:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		if "ssl" in updater.error_msg.lower():
-			split.enabled = True
-			split.operator(AddonUpdaterInstallManually.bl_idname,
-						   text=updater.error)
-		else:
-			split.enabled = False
-			split.operator(AddonUpdaterCheckNow.bl_idname,
-						   text=updater.error)
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    col = row.column()
+    if updater.error is not None:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        if "ssl" in updater.error_msg.lower():
+            split.enabled = True
+            split.operator(AddonUpdaterInstallManually.bl_idname,
+                           text=updater.error)
+        else:
+            split.enabled = False
+            split.operator(AddonUpdaterCheckNow.bl_idname,
+                           text=updater.error)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready is None and not updater.async_checking:
-		col.scale_y = 2
-		col.operator(AddonUpdaterCheckNow.bl_idname)
-	elif updater.update_ready is None:  # async is running
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
+    elif updater.update_ready is None and not updater.async_checking:
+        col.scale_y = 2
+        col.operator(AddonUpdaterCheckNow.bl_idname)
+    elif updater.update_ready is None:  # async is running
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
 
-	elif updater.include_branches and \
-			len(updater.tags) == len(updater.include_branch_list) and not \
-			updater.manual_only:
-		# no releases found, but still show the appropriate branch
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update directly to " + str(updater.include_branch_list[0]))
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.include_branches and \
+            len(updater.tags) == len(updater.include_branch_list) and not \
+            updater.manual_only:
+        # no releases found, but still show the appropriate branch
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterUpdateNow.bl_idname,
+                       text="Update directly to " + str(updater.include_branch_list[0]))
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready and not updater.manual_only:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update now to " + str(updater.update_version))
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_ready and not updater.manual_only:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterUpdateNow.bl_idname,
+                       text="Update now to " + str(updater.update_version))
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready and updater.manual_only:
-		col.scale_y = 2
-		col.operator("wm.url_open",
-				text="Download " + str(updater.update_version)).url = updater.website
-	else:  # i.e. that updater.update_ready == False
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="Addon is up to date")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_ready and updater.manual_only:
+        col.scale_y = 2
+        col.operator("wm.url_open",
+                text="Download " + str(updater.update_version)).url = updater.website
+    else:  # i.e. that updater.update_ready == False
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="Addon is up to date")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname,
+                       text="", icon="FILE_REFRESH")
 
-	row = element.row()
-	row.prop(settings, "auto_check_update")
+    row = element.row()
+    row.prop(settings, "auto_check_update")
 
-	row = element.row()
-	row.scale_y = 0.7
-	last_check = updater.json["last_check"]
-	if updater.error is not None and updater.error_msg is not None:
-		row.label(text=updater.error_msg)
-	elif last_check != "" and last_check is not None:
-		last_check = last_check[0: last_check.index(".")]
-		row.label(text="Last check: " + last_check)
-	else:
-		row.label(text="Last check: Never")
+    row = element.row()
+    row.scale_y = 0.7
+    last_check = updater.json["last_check"]
+    if updater.error is not None and updater.error_msg is not None:
+        row.label(text=updater.error_msg)
+    elif last_check != "" and last_check is not None:
+        last_check = last_check[0: last_check.index(".")]
+        row.label(text="Last check: " + last_check)
+    else:
+        row.label(text="Last check: Never")
 
 
 def skip_tag_function(self, tag):
-	"""A global function for tag skipping
+    """A global function for tag skipping
 
-	A way to filter which tags are displayed,
-	e.g. to limit downgrading too far
-	input is a tag text, e.g. "v1.2.3"
-	output is True for skipping this tag number,
-	False if the tag is allowed (default for all)
-	Note: here, "self" is the acting updater shared class instance
-	"""
+    A way to filter which tags are displayed,
+    e.g. to limit downgrading too far
+    input is a tag text, e.g. "v1.2.3"
+    output is True for skipping this tag number,
+    False if the tag is allowed (default for all)
+    Note: here, "self" is the acting updater shared class instance
+    """
 
-	# in case of error importing updater
-	if self.invalid_updater:
-		return False
+    # in case of error importing updater
+    if self.invalid_updater:
+        return False
 
-	# ---- write any custom code here, return true to disallow version ---- #
-	#
-	# # Filter out e.g. if 'beta' is in name of release
-	# if 'beta' in tag.lower():
-	# 	return True
-	# ---- write any custom code above, return true to disallow version --- #
+    # ---- write any custom code here, return true to disallow version ---- #
+    #
+    # # Filter out e.g. if 'beta' is in name of release
+    # if 'beta' in tag.lower():
+    # 	return True
+    # ---- write any custom code above, return true to disallow version --- #
 
-	if self.include_branches:
-		for branch in self.include_branch_list:
-			if tag["name"].lower() == branch: return False
+    if self.include_branches:
+        for branch in self.include_branch_list:
+            if tag["name"].lower() == branch: return False
 
-	# function converting string to tuple, ignoring e.g. leading 'v'
-	tupled = self.version_tuple_from_text(tag["name"])
-	if not isinstance(tupled, tuple):
-		return True
+    # function converting string to tuple, ignoring e.g. leading 'v'
+    tupled = self.version_tuple_from_text(tag["name"])
+    if not isinstance(tupled, tuple):
+        return True
 
-	# select the min tag version - change tuple accordingly
-	if self.version_min_update is not None:
-		if tupled < self.version_min_update:
-			return True  # skip if current version below this
+    # select the min tag version - change tuple accordingly
+    if self.version_min_update is not None:
+        if tupled < self.version_min_update:
+            return True  # skip if current version below this
 
-	# select the max tag version
-	if self.version_max_update is not None:
-		if tupled >= self.version_max_update:
-			return True  # skip if current version at or above this
+    # select the max tag version
+    if self.version_max_update is not None:
+        if tupled >= self.version_max_update:
+            return True  # skip if current version at or above this
 
-	# in all other cases, allow showing the tag for updating/reverting
-	return False
+    # in all other cases, allow showing the tag for updating/reverting
+    return False
 
 
 def select_link_function(self, tag):
-	"""Only customize if trying to leverage "attachments" in *GitHub* releases
+    """Only customize if trying to leverage "attachments" in *GitHub* releases
 
-	A way to select from one or multiple attached downloadable files from the
-	server, instead of downloading the default release/tag source code
-	"""
+    A way to select from one or multiple attached downloadable files from the
+    server, instead of downloading the default release/tag source code
+    """
 
-	# -- Default, universal case (and is the only option for GitLab/Bitbucket)
-	link = tag["zipball_url"]
+    # -- Default, universal case (and is the only option for GitLab/Bitbucket)
+    link = tag["zipball_url"]
 
-	# -- Example: select the first (or only) asset instead source code --
-	# if "assets" in tag and "browser_download_url" in tag["assets"][0]:
-	# 	link = tag["assets"][0]["browser_download_url"]
+    # -- Example: select the first (or only) asset instead source code --
+    # if "assets" in tag and "browser_download_url" in tag["assets"][0]:
+    # 	link = tag["assets"][0]["browser_download_url"]
 
-	# -- Example: select asset based on OS, where multiple builds exist --
-	# # not tested/no error checking, modify to fit your own needs!
-	# # assume each release has three attached builds:
-	# #		release_windows.zip, release_OSX.zip, release_linux.zip
-	# # This also would logically not be used with "branches" enabled
-	# if platform.system() == "Darwin": # ie OSX
-	# 	link = [asset for asset in tag["assets"] if 'OSX' in asset][0]
-	# elif platform.system() == "Windows":
-	# 	link = [asset for asset in tag["assets"] if 'windows' in asset][0]
-	# elif platform.system() == "Linux":
-	# 	link = [asset for asset in tag["assets"] if 'linux' in asset][0]
+    # -- Example: select asset based on OS, where multiple builds exist --
+    # # not tested/no error checking, modify to fit your own needs!
+    # # assume each release has three attached builds:
+    # #		release_windows.zip, release_OSX.zip, release_linux.zip
+    # # This also would logically not be used with "branches" enabled
+    # if platform.system() == "Darwin": # ie OSX
+    # 	link = [asset for asset in tag["assets"] if 'OSX' in asset][0]
+    # elif platform.system() == "Windows":
+    # 	link = [asset for asset in tag["assets"] if 'windows' in asset][0]
+    # elif platform.system() == "Linux":
+    # 	link = [asset for asset in tag["assets"] if 'linux' in asset][0]
 
-	return link
+    return link
 
 
 # -----------------------------------------------------------------------------
 # Register, should be run in the register module itself
 # -----------------------------------------------------------------------------
 classes = (
-	AddonUpdaterInstallPopup,
-	AddonUpdaterCheckNow,
-	AddonUpdaterUpdateNow,
-	AddonUpdaterUpdateTarget,
-	AddonUpdaterInstallManually,
-	AddonUpdaterUpdatedSuccessful,
-	AddonUpdaterRestoreBackup,
-	AddonUpdaterIgnore,
-	AddonUpdaterEndBackground
+    AddonUpdaterInstallPopup,
+    AddonUpdaterCheckNow,
+    AddonUpdaterUpdateNow,
+    AddonUpdaterUpdateTarget,
+    AddonUpdaterInstallManually,
+    AddonUpdaterUpdatedSuccessful,
+    AddonUpdaterRestoreBackup,
+    AddonUpdaterIgnore,
+    AddonUpdaterEndBackground
 )
 
 
 def register(bl_info):
-	"""Registering the operators in this module"""
-	# safer failure in case of issue loading module
-	if updater.error:
-		print("Exiting updater registration, " + updater.error)
-		return
-	updater.clear_state()  # clear internal vars, avoids reloading oddities
+    """Registering the operators in this module"""
+    # safer failure in case of issue loading module
+    if updater.error:
+        print("Exiting updater registration, " + updater.error)
+        return
+    updater.clear_state()  # clear internal vars, avoids reloading oddities
 
-	# confirm your updater "engine" (Github is default if not specified)
-	updater.engine = "Github"
-	# updater.engine = "GitLab"
-	# updater.engine = "Bitbucket"
+    # confirm your updater "engine" (Github is default if not specified)
+    updater.engine = "Github"
+    # updater.engine = "GitLab"
+    # updater.engine = "Bitbucket"
 
-	# If using private repository, indicate the token here
-	# Must be set after assigning the engine.
-	# **WARNING** Depending on the engine, this token can act like a password!!
-	# Only provide a token if the project is *non-public*, see readme for
-	# other considerations and suggestions from a security standpoint
-	updater.private_token = None  # "tokenstring"
+    # If using private repository, indicate the token here
+    # Must be set after assigning the engine.
+    # **WARNING** Depending on the engine, this token can act like a password!!
+    # Only provide a token if the project is *non-public*, see readme for
+    # other considerations and suggestions from a security standpoint
+    updater.private_token = None  # "tokenstring"
 
-	# choose your own username, must match website (not needed for GitLab)
-	updater.user = "cgcookie"
+    # choose your own username, must match website (not needed for GitLab)
+    updater.user = "cgcookie"
 
-	# choose your own repository, must match git name for GitHUb and Bitbucket,
-	# for GitLab use project ID (numbers only)
-	updater.repo = "blender-addon-updater"
+    # choose your own repository, must match git name for GitHUb and Bitbucket,
+    # for GitLab use project ID (numbers only)
+    updater.repo = "blender-addon-updater"
 
-	# updater.addon = # define at top of module, MUST be done first
+    # updater.addon = # define at top of module, MUST be done first
 
-	# Website for manual addon download, optional but recommended to set
-	updater.website = "https://github.com/CGCookie/blender-addon-updater/"
+    # Website for manual addon download, optional but recommended to set
+    updater.website = "https://github.com/CGCookie/blender-addon-updater/"
 
-	# Addon subfolder path
-	# "sample/path/to/addon"
-	# default is "" or None, meaning root
-	updater.subfolder_path = ""
+    # Addon subfolder path
+    # "sample/path/to/addon"
+    # default is "" or None, meaning root
+    updater.subfolder_path = ""
 
-	# used to check/compare versions
-	updater.current_version = bl_info["version"]
+    # used to check/compare versions
+    updater.current_version = bl_info["version"]
 
-	# Optional, to hard-set update frequency, use this here - however,
-	# this demo has this set via UI properties.
-	# updater.set_check_interval(
-	# 		enable=False,months=0,days=0,hours=0,minutes=2)
+    # Optional, to hard-set update frequency, use this here - however,
+    # this demo has this set via UI properties.
+    # updater.set_check_interval(
+    # 		enable=False,months=0,days=0,hours=0,minutes=2)
 
-	# Optional, consider turning off for production or allow as an option
-	# This will print out additional debugging info to the console
-	updater.verbose = True  # make False for production default
+    # Optional, consider turning off for production or allow as an option
+    # This will print out additional debugging info to the console
+    updater.verbose = True  # make False for production default
 
-	# Optional, customize where the addon updater processing subfolder is,
-	# essentially a staging folder used by the updater on its own
-	# Needs to be within the same folder as the addon itself
-	# Need to supply a full, absolute path to folder
-	# updater.updater_path = # set path of updater folder, by default:
-	# 			/addons/{__package__}/{__package__}_updater
+    # Optional, customize where the addon updater processing subfolder is,
+    # essentially a staging folder used by the updater on its own
+    # Needs to be within the same folder as the addon itself
+    # Need to supply a full, absolute path to folder
+    # updater.updater_path = # set path of updater folder, by default:
+    # 			/addons/{__package__}/{__package__}_updater
 
-	# auto create a backup of the addon when installing other versions
-	updater.backup_current = True  # True by default
+    # auto create a backup of the addon when installing other versions
+    updater.backup_current = True  # True by default
 
-	# Sample ignore patterns for when creating backup of current during update
-	updater.backup_ignore_patterns = ["__pycache__"]
-	# Alternate example patterns
-	# updater.backup_ignore_patterns = [".git", "__pycache__", "*.bat", ".gitignore", "*.exe"]
+    # Sample ignore patterns for when creating backup of current during update
+    updater.backup_ignore_patterns = ["__pycache__"]
+    # Alternate example patterns
+    # updater.backup_ignore_patterns = [".git", "__pycache__", "*.bat", ".gitignore", "*.exe"]
 
-	# Patterns for files to actively overwrite if found in new update
-	# file and are also found in the currently installed addon. Note that
+    # Patterns for files to actively overwrite if found in new update
+    # file and are also found in the currently installed addon. Note that
 
-	# by default (ie if set to []), updates are installed in the same way as blender:
-	# .py files are replaced, but other file types (e.g. json, txt, blend)
-	# will NOT be overwritten if already present in current install. Thus
-	# if you want to automatically update resources/non py files, add them
-	# as a part of the pattern list below so they will always be overwritten by an
-	# update. If a pattern file is not found in new update, no action is taken
-	# This does NOT delete anything, only defines what is allowed to be overwritten
-	updater.overwrite_patterns = ["*.png", "*.jpg", "README.md", "LICENSE.txt"]
-	# updater.overwrite_patterns = []
-	# other examples:
-	# ["*"] means ALL files/folders will be overwritten by update, was the behavior pre updater v1.0.4
-	# [] or ["*.py","*.pyc"] matches default blender behavior, ie same effect if user installs update manually without deleting the existing addon first
-	#    e.g. if existing install and update both have a resource.blend file, the existing installed one will remain
-	# ["some.py"] means if some.py is found in addon update, it will overwrite any existing some.py in current addon install, if any
-	# ["*.json"] means all json files found in addon update will overwrite those of same name in current install
-	# ["*.png","README.md","LICENSE.txt"] means the readme, license, and all pngs will be overwritten by update
+    # by default (ie if set to []), updates are installed in the same way as blender:
+    # .py files are replaced, but other file types (e.g. json, txt, blend)
+    # will NOT be overwritten if already present in current install. Thus
+    # if you want to automatically update resources/non py files, add them
+    # as a part of the pattern list below so they will always be overwritten by an
+    # update. If a pattern file is not found in new update, no action is taken
+    # This does NOT delete anything, only defines what is allowed to be overwritten
+    updater.overwrite_patterns = ["*.png", "*.jpg", "README.md", "LICENSE.txt"]
+    # updater.overwrite_patterns = []
+    # other examples:
+    # ["*"] means ALL files/folders will be overwritten by update, was the behavior pre updater v1.0.4
+    # [] or ["*.py","*.pyc"] matches default blender behavior, ie same effect if user installs update manually without deleting the existing addon first
+    #    e.g. if existing install and update both have a resource.blend file, the existing installed one will remain
+    # ["some.py"] means if some.py is found in addon update, it will overwrite any existing some.py in current addon install, if any
+    # ["*.json"] means all json files found in addon update will overwrite those of same name in current install
+    # ["*.png","README.md","LICENSE.txt"] means the readme, license, and all pngs will be overwritten by update
 
-	# Patterns for files to actively remove prior to running update
-	# Useful if wanting to remove old code due to changes in filenames
-	# that otherwise would accumulate. Note: this runs after taking
-	# a backup (if enabled) but before placing in new update. If the same
-	# file name removed exists in the update, then it acts as if pattern
-	# is placed in the overwrite_patterns property. Note this is effectively
-	# ignored if clean=True in the run_update method
-	updater.remove_pre_update_patterns = ["*.py", "*.pyc"]
-	# Note setting ["*"] here is equivalent to always running updates with
-	# clean = True in the run_update method, ie the equivalent of a fresh,
-	# new install. This would also delete any resources or user-made/modified
-	# files setting ["__pycache__"] ensures the pycache folder is always removed
-	# The configuration of ["*.py","*.pyc"] is a safe option as this
-	# will ensure no old python files/caches remain in event different addon
-	# versions have different filenames or structures
+    # Patterns for files to actively remove prior to running update
+    # Useful if wanting to remove old code due to changes in filenames
+    # that otherwise would accumulate. Note: this runs after taking
+    # a backup (if enabled) but before placing in new update. If the same
+    # file name removed exists in the update, then it acts as if pattern
+    # is placed in the overwrite_patterns property. Note this is effectively
+    # ignored if clean=True in the run_update method
+    updater.remove_pre_update_patterns = ["*.py", "*.pyc"]
+    # Note setting ["*"] here is equivalent to always running updates with
+    # clean = True in the run_update method, ie the equivalent of a fresh,
+    # new install. This would also delete any resources or user-made/modified
+    # files setting ["__pycache__"] ensures the pycache folder is always removed
+    # The configuration of ["*.py","*.pyc"] is a safe option as this
+    # will ensure no old python files/caches remain in event different addon
+    # versions have different filenames or structures
 
-	# Allow branches like 'master' as an option to update to, regardless
-	# of release or version.
-	# Default behavior: releases will still be used for auto check (popup),
-	# but the user has the option from user preferences to directly
-	# update to the master branch or any other branches specified using
-	# the "install {branch}/older version" operator.
-	updater.include_branches = True
+    # Allow branches like 'master' as an option to update to, regardless
+    # of release or version.
+    # Default behavior: releases will still be used for auto check (popup),
+    # but the user has the option from user preferences to directly
+    # update to the master branch or any other branches specified using
+    # the "install {branch}/older version" operator.
+    updater.include_branches = True
 
-	# (GitHub only) This options allows the user to use releases over tags for data,
-	# which enables pulling down release logs/notes, as well as specify installs from
-	# release-attached zips (instead of just the auto-packaged code generated with
-	# a release/tag). Setting has no impact on BitBucket or GitLab repos
-	updater.use_releases = False
-	# note: Releases always have a tag, but a tag may not always be a release
-	# Therefore, setting True above will filter out any non-annotated tags
-	# note 2: Using this option will also display the release name instead of
-	# just the tag name, bear this in mind given the skip_tag_function filtering above
+    # (GitHub only) This options allows the user to use releases over tags for data,
+    # which enables pulling down release logs/notes, as well as specify installs from
+    # release-attached zips (instead of just the auto-packaged code generated with
+    # a release/tag). Setting has no impact on BitBucket or GitLab repos
+    updater.use_releases = False
+    # note: Releases always have a tag, but a tag may not always be a release
+    # Therefore, setting True above will filter out any non-annotated tags
+    # note 2: Using this option will also display the release name instead of
+    # just the tag name, bear this in mind given the skip_tag_function filtering above
 
-	# if using "include_branches",
-	# updater.include_branch_list defaults to ['master'] branch if set to none
-	# example targeting another multiple branches allowed to pull from
-	# updater.include_branch_list = ['master', 'dev'] # example with two branches
-	updater.include_branch_list = None  # None is the equivalent to setting ['master']
+    # if using "include_branches",
+    # updater.include_branch_list defaults to ['master'] branch if set to none
+    # example targeting another multiple branches allowed to pull from
+    # updater.include_branch_list = ['master', 'dev'] # example with two branches
+    updater.include_branch_list = None  # None is the equivalent to setting ['master']
 
-	# Only allow manual install, thus prompting the user to open
-	# the addon's web page to download, specifically: updater.website
-	# Useful if only wanting to get notification of updates but not
-	# directly install.
-	updater.manual_only = False
+    # Only allow manual install, thus prompting the user to open
+    # the addon's web page to download, specifically: updater.website
+    # Useful if only wanting to get notification of updates but not
+    # directly install.
+    updater.manual_only = False
 
-	# Used for development only, "pretend" to install an update to test
-	# reloading conditions
-	updater.fake_install = False  # Set to true to test callback/reloading
+    # Used for development only, "pretend" to install an update to test
+    # reloading conditions
+    updater.fake_install = False  # Set to true to test callback/reloading
 
-	# Show popups, ie if auto-check for update is enabled or a previous
-	# check for update in user preferences found a new version, show a popup
-	# (at most once per blender session, and it provides an option to ignore
-	# for future sessions); default behavior is set to True
-	updater.show_popups = True
-	# note: if set to false, there will still be an "update ready" box drawn
-	# using the `update_notice_box_ui` panel function.
+    # Show popups, ie if auto-check for update is enabled or a previous
+    # check for update in user preferences found a new version, show a popup
+    # (at most once per blender session, and it provides an option to ignore
+    # for future sessions); default behavior is set to True
+    updater.show_popups = True
+    # note: if set to false, there will still be an "update ready" box drawn
+    # using the `update_notice_box_ui` panel function.
 
-	# Override with a custom function on what tags
-	# to skip showing for updater; see code for function above.
-	# Set the min and max versions allowed to install.
-	# Optional, default None
-	# min install (>=) will install this and higher
-	updater.version_min_update = (0, 0, 0)
-	# updater.version_min_update = None  # if not wanting to define a min
+    # Override with a custom function on what tags
+    # to skip showing for updater; see code for function above.
+    # Set the min and max versions allowed to install.
+    # Optional, default None
+    # min install (>=) will install this and higher
+    updater.version_min_update = (0, 0, 0)
+    # updater.version_min_update = None  # if not wanting to define a min
 
-	# max install (<) will install strictly anything lower
-	# updater.version_max_update = (9,9,9)
-	updater.version_max_update = None  # set to None if not wanting to set max
+    # max install (<) will install strictly anything lower
+    # updater.version_max_update = (9,9,9)
+    updater.version_max_update = None  # set to None if not wanting to set max
 
-	# Function defined above, customize as appropriate per repository
-	updater.skip_tag = skip_tag_function  # min and max used in this function
+    # Function defined above, customize as appropriate per repository
+    updater.skip_tag = skip_tag_function  # min and max used in this function
 
-	# Function defined above, customize as appropriate per repository; not required
-	updater.select_link = select_link_function
+    # Function defined above, customize as appropriate per repository; not required
+    updater.select_link = select_link_function
 
-	# Recommended false to encourage blender restarts on update completion
-	# Setting this option to True is NOT as stable as false (could cause
-	# blender crashes)
-	updater.auto_reload_post_update = False
+    # Recommended false to encourage blender restarts on update completion
+    # Setting this option to True is NOT as stable as false (could cause
+    # blender crashes)
+    updater.auto_reload_post_update = False
 
-	# The register line items for all operators/panels
-	# If using bpy.utils.register_module(__name__) to register elsewhere
-	# in the addon, delete these lines (also from unregister)
-	for cls in classes:
-		# apply annotations to remove Blender 2.8 warnings, no effect on 2.7
-		make_annotations(cls)
-		# comment out this line if using bpy.utils.register_module(__name__)
-		bpy.utils.register_class(cls)
+    # The register line items for all operators/panels
+    # If using bpy.utils.register_module(__name__) to register elsewhere
+    # in the addon, delete these lines (also from unregister)
+    for cls in classes:
+        # apply annotations to remove Blender 2.8 warnings, no effect on 2.7
+        make_annotations(cls)
+        # comment out this line if using bpy.utils.register_module(__name__)
+        bpy.utils.register_class(cls)
 
-	# special situation: we just updated the addon, show a popup
-	# to tell the user it worked
-	# should be enclosed in try/catch in case other issues arise
-	show_reload_popup()
+    # special situation: we just updated the addon, show a popup
+    # to tell the user it worked
+    # should be enclosed in try/catch in case other issues arise
+    show_reload_popup()
 
 
 def unregister():
-	for cls in reversed(classes):
-		# comment out this line if using bpy.utils.unregister_module(__name__)
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        # comment out this line if using bpy.utils.unregister_module(__name__)
+        bpy.utils.unregister_class(cls)
 
-	# clear global vars since they may persist if not restarting blender
-	updater.clear_state()  # clear internal vars, avoids reloading oddities
+    # clear global vars since they may persist if not restarting blender
+    updater.clear_state()  # clear internal vars, avoids reloading oddities
 
-	global ran_auto_check_install_popup
-	ran_auto_check_install_popup = False
+    global ran_auto_check_install_popup
+    ran_auto_check_install_popup = False
 
-	global ran_update_success_popup
-	ran_update_success_popup = False
+    global ran_update_success_popup
+    ran_update_success_popup = False
 
-	global ran_background_check
-	ran_background_check = False
+    global ran_background_check
+    ran_background_check = False

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -789,11 +789,11 @@ def check_for_update_background():
     if not settings:
         return
     updater.set_check_interval(enable=settings.auto_check_update,
-                months=settings.updater_interval_months,
-                days=settings.updater_interval_days,
-                hours=settings.updater_interval_hours,
-                minutes=settings.updater_interval_minutes
-                )  # optional, if auto_check_update
+                               months=settings.updater_interval_months,
+                               days=settings.updater_interval_days,
+                               hours=settings.updater_interval_hours,
+                               minutes=settings.updater_interval_minutes
+                               )  # optional, if auto_check_update
 
     # input is an optional callback function
     # this function should take a bool input, if true: update ready
@@ -819,10 +819,10 @@ def check_for_update_nonthreaded(self, context):
                 __package__))
         return
     updater.set_check_interval(enable=settings.auto_check_update,
-                               months=settings.updater_intrval_months,
-                               days=settings.updater_intrval_days,
-                               hours=settings.updater_intrval_hours,
-                               minutes=settings.updater_intrval_minutes)  # optional, if auto_check_update
+                               months=settings.updater_interval_months,
+                               days=settings.updater_interval_days,
+                               hours=settings.updater_interval_hours,
+                               minutes=settings.updater_interval_minutes)  # optional, if auto_check_update
 
     (update_ready, version, link) = updater.check_for_update(now=False)
     if update_ready:

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -247,7 +247,7 @@ class AddonUpdaterCheckNow(bpy.types.Operator):
             return {'CANCELLED'}
 
         updater.set_check_interval(
-            enable=settings.auto_check_update,
+            enabled=settings.auto_check_update,
             months=settings.updater_interval_months,
             days=settings.updater_interval_days,
             hours=settings.updater_interval_hours,
@@ -788,7 +788,7 @@ def check_for_update_background():
     settings = get_user_preferences(bpy.context)
     if not settings:
         return
-    updater.set_check_interval(enable=settings.auto_check_update,
+    updater.set_check_interval(enabled=settings.auto_check_update,
                                months=settings.updater_interval_months,
                                days=settings.updater_interval_days,
                                hours=settings.updater_interval_hours,
@@ -818,7 +818,7 @@ def check_for_update_nonthreaded(self, context):
             print("Could not get {} preferences, update check skipped".format(
                 __package__))
         return
-    updater.set_check_interval(enable=settings.auto_check_update,
+    updater.set_check_interval(enabled=settings.auto_check_update,
                                months=settings.updater_interval_months,
                                days=settings.updater_interval_days,
                                hours=settings.updater_interval_hours,
@@ -1025,12 +1025,10 @@ def update_settings_ui(self, context, element=None):
         split = sub_col.split(align=True)
         split.enabled = False
         split.scale_y = 2
-        split.operator(AddonUpdaterCheckNow.bl_idname,
-                       text="Checking...")
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
         split = sub_col.split(align=True)
         split.scale_y = 2
-        split.operator(AddonUpdaterEndBackground.bl_idname,
-                       text="", icon="X")
+        split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
 
     elif updater.include_branches and \
             len(updater.tags) == len(updater.include_branch_list) and not \
@@ -1364,8 +1362,7 @@ def register(bl_info):
 
     # Optional, to hard-set update frequency, use this here - however,
     # this demo has this set via UI properties.
-    # updater.set_check_interval(
-    # 		enable=False,months=0,days=0,hours=0,minutes=2)
+    # updater.set_check_interval(enabled=False, months=0, days=0, hours=0, minutes=2)
 
     # Optional, consider turning off for production or allow as an option
     # This will print out additional debugging info to the console

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -54,9 +54,11 @@ except Exception as e:
             self.error_msg = None
             self.async_checking = None
 
-        def run_update(self): pass
+        def run_update(self, force, callback, clean):
+            pass
 
-        def check_for_update(self): pass
+        def check_for_update(self, now):
+            pass
 
     updater = SingletonUpdaterNone()
     updater.error = "Error initializing updater module"
@@ -158,7 +160,7 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
             col = layout.column()
             col.scale_y = 0.7
             col.label(text="Update {} ready!".format(str(updater.update_version)),
-                        icon="LOOP_FORWARDS")
+                      icon="LOOP_FORWARDS")
             col.label(text="Choose 'Update Now' & press OK to install, ", icon="BLANK1")
             col.label(text="or click outside window to defer", icon="BLANK1")
             row = col.row()
@@ -197,8 +199,8 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
             # else: "install update now!"
 
             res = updater.run_update(force=False,
-                                    callback=post_update_callback,
-                                    clean=self.clean_install)
+                                     callback=post_update_callback,
+                                     clean=self.clean_install)
 
             # should return 0, if not something happened
             if updater.verbose:
@@ -287,10 +289,9 @@ class AddonUpdaterUpdateNow(bpy.types.Operator):
         if updater.update_ready:
             # if it fails, offer to open the website instead
             try:
-                res = updater.run_update(
-                    force=False,
-                    callback=post_update_callback,
-                    clean=self.clean_install)
+                res = updater.run_update(force=False,
+                                         callback=post_update_callback,
+                                         clean=self.clean_install)
 
                 # should return 0, if not something happened
                 if updater.verbose:
@@ -788,10 +789,10 @@ def check_for_update_background():
     if not settings:
         return
     updater.set_check_interval(enable=settings.auto_check_update,
-                months=settings.updater_intrval_months,
-                days=settings.updater_intrval_days,
-                hours=settings.updater_intrval_hours,
-                minutes=settings.updater_intrval_minutes
+                months=settings.updater_interval_months,
+                days=settings.updater_interval_days,
+                hours=settings.updater_interval_hours,
+                minutes=settings.updater_interval_minutes
                 )  # optional, if auto_check_update
 
     # input is an optional callback function
@@ -818,10 +819,10 @@ def check_for_update_nonthreaded(self, context):
                 __package__))
         return
     updater.set_check_interval(enable=settings.auto_check_update,
-                months=settings.updater_intrval_months,
-                days=settings.updater_intrval_days,
-                hours=settings.updater_intrval_hours,
-                minutes=settings.updater_intrval_minutes)  # optional, if auto_check_update
+                               months=settings.updater_intrval_months,
+                               days=settings.updater_intrval_days,
+                               hours=settings.updater_intrval_hours,
+                               minutes=settings.updater_intrval_minutes)  # optional, if auto_check_update
 
     (update_ready, version, link) = updater.check_for_update(now=False)
     if update_ready:
@@ -968,10 +969,9 @@ def update_settings_ui(self, context, element=None):
         saved_state = updater.json
         if "just_updated" in saved_state and saved_state["just_updated"]:
             row.alert = True
-            row.operator(
-                "wm.quit_blender",
-                text="Restart blender to complete update",
-                icon="ERROR")
+            row.operator("wm.quit_blender",
+                         text="Restart blender to complete update",
+                         icon="ERROR")
             return
 
     split = layout_split(row, factor=0.4)
@@ -1062,7 +1062,7 @@ def update_settings_ui(self, context, element=None):
     elif updater.update_ready and updater.manual_only:
         col.scale_y = 2
         col.operator("wm.url_open",
-                text="Download " + str(updater.update_version)).url = updater.website
+                     text="Download " + str(updater.update_version)).url = updater.website
     else:  # i.e. that updater.update_ready == False
         sub_col = col.row(align=True)
         sub_col.scale_y = 1
@@ -1203,7 +1203,7 @@ def update_settings_ui_condensed(self, context, element=None):
     elif updater.update_ready and updater.manual_only:
         col.scale_y = 2
         col.operator("wm.url_open",
-                text="Download " + str(updater.update_version)).url = updater.website
+                     text="Download " + str(updater.update_version)).url = updater.website
     else:  # i.e. that updater.update_ready == False
         sub_col = col.row(align=True)
         sub_col.scale_y = 1

--- a/tests/addon_updater_test.py
+++ b/tests/addon_updater_test.py
@@ -80,7 +80,7 @@ class TestEngines(unittest.TestCase):
 		self.run_engine_test(updater)
 
 	def test_github(self):
-		"""Test the gitlab updater"""
+		"""Test the Github updater"""
 
 		updater = addon_updater.Singleton_updater()
 		updater.engine = "Github"
@@ -96,7 +96,7 @@ class TestEngines(unittest.TestCase):
 		self.run_engine_test(updater)
 
 	def test_bitbucket(self):
-		"""Test the bitbucket updater"""
+		"""Test the Bitbucket updater"""
 
 		updater = addon_updater.Singleton_updater()
 		updater.engine = "Bitbucket"
@@ -121,14 +121,15 @@ class TestEngines(unittest.TestCase):
 		updater._addon_root = UPDATER_MODULE_DIR
 		updater.verbose = False
 
-		updater.current_version = (1,0,0)
+		updater.current_version = (1, 0, 0)
 		updater.backup_current = False
 		updater.include_branches = True
 		updater.use_releases = False
 
 		# Test raw API call
 		tag_url = updater.form_tags_url()
-		branch_url = updater.form_branch_url("master")
+		_ = updater.form_branch_url("master")
+		# branch_url = updater.form_branch_url("master")
 		# parsed_tag = updater._engine.parse_tags()
 
 		# verify ths raw request doesn't fail
@@ -139,11 +140,11 @@ class TestEngines(unittest.TestCase):
 		# verify and check output of parse request
 		res = updater.get_api(tag_url)
 		self.assertIsNotNone(res)
-		self.assertTrue(len(res)>0)
+		self.assertTrue(len(res) > 0)
 
 		# Test the end to end get tag names request
 		tags = updater._get_tag_names()
-		self.assertTrue(len(tags)>0)
+		self.assertTrue(len(tags) > 0)
 		# print("Found {} tags".format(len(tags)))
 
 		# Grab link to an archive (should be master for all)
@@ -168,7 +169,7 @@ class TestEngines(unittest.TestCase):
 		self.assertTrue(updater._update_ready)
 
 		# Test the synchronous check function, knowing it should have no update
-		updater.current_version = (99,0,0)
+		updater.current_version = (99, 0, 0)
 		updater._update_ready = None
 		updater.check_for_update()
 		self.assertFalse(updater._update_ready)
@@ -195,15 +196,15 @@ class TestFunctions(unittest.TestCase):
 		"""Test tuple extraction examples"""
 
 		updater = addon_updater.Singleton_updater()
-		updater.include_branches = False # otherwise could treat as branch name
+		updater.include_branches = False  # otherwise could treat as branch name
 
 		# structure of: input, expected
 		test_cases = [
-			["0.0.0", (0,0,0)],
-			["v0.0.0", (0,0,0)],
-			["v0.0", (0,0)],
-			["v0.0 beta", (0,0)],
-			["version 1,2,3 beta", (1,2,3)]
+			["0.0.0", (0, 0, 0)],
+			["v0.0.0", (0, 0, 0)],
+			["v0.0", (0, 0)],
+			["v0.0 beta", (0, 0)],
+			["version 1,2,3 beta", (1, 2, 3)]
 		]
 
 		for case in test_cases:
@@ -214,8 +215,8 @@ class TestFunctions(unittest.TestCase):
 		"""Test the reload function which disables and re-enables addon"""
 		updater = addon_updater.Singleton_updater()
 		updater.auto_reload_post_update = True
-		updater._addon_package = "blender-addon-updater-github" # test override
-		updater.reload_addon() # assert no error
+		updater._addon_package = "blender-addon-updater-github"  # test override
+		updater.reload_addon()  # assert no error
 
 
 if __name__ == '__main__':

--- a/tests/addon_updater_test.py
+++ b/tests/addon_updater_test.py
@@ -142,7 +142,7 @@ class TestEngines(unittest.TestCase):
 		self.assertTrue(len(res)>0)
 
 		# Test the end to end get tag names request
-		tags = updater.get_tag_names()
+		tags = updater._get_tag_names()
 		self.assertTrue(len(tags)>0)
 		# print("Found {} tags".format(len(tags)))
 

--- a/tests/addon_updater_test.py
+++ b/tests/addon_updater_test.py
@@ -22,21 +22,21 @@ Runs tests for each of the engines and major modules, including integration
 tests with the actual services.
 
 How to run inside blender interface (script editor):
-	Open this file in a blender text editor, and press run.
-	Because some code in the addon_updater.py file still require bpy, it must
-	be run this way in the context of blender. However, tests will run by
-	directly reading the code next this python file in the git repository.
+    Open this file in a blender text editor, and press run.
+    Because some code in the addon_updater.py file still require bpy, it must
+    be run this way in the context of blender. However, tests will run by
+    directly reading the code next this python file in the git repository.
 
 How to run from command line (run blender from within tests folder)
-	# Run all tests
-	blender -b -P addon_updater_test.py
+    # Run all tests
+    blender -b -P addon_updater_test.py
 
-	# Run all tests within single class
-	blender -b -P addon_updater_test.py -- TestEngines
+    # Run all tests within single class
+    blender -b -P addon_updater_test.py -- TestEngines
 
-	# Run specific test
-	blender -b -P addon_updater_test.py -- TestEngines.test_gitlab
-	blender -b -P addon_updater_test.py -- TestFunctions.test_version_tuple_from_text
+    # Run specific test
+    blender -b -P addon_updater_test.py -- TestEngines.test_gitlab
+    blender -b -P addon_updater_test.py -- TestFunctions.test_version_tuple_from_text
 
 Note! Running multiple tests in succession could lead to API rate limitations,
 which will manifest primarily as errors in the TestEngines unit tests.
@@ -49,14 +49,14 @@ import unittest
 import bpy
 
 if "text" in dir(bpy.context.space_data):
-	# Running inside the python console in blender
-	UPDATER_MODULE_DIR = os.path.dirname(os.path.dirname(
-		bpy.path.abspath(bpy.context.space_data.text.filepath)))
-	QUIT_ON_COMPLETE = False
+    # Running inside the python console in blender
+    UPDATER_MODULE_DIR = os.path.dirname(os.path.dirname(
+        bpy.path.abspath(bpy.context.space_data.text.filepath)))
+    QUIT_ON_COMPLETE = False
 else:
-	# Commandline script passed to blender, directory should be //tests/
-	UPDATER_MODULE_DIR = os.path.dirname(os.getcwd())
-	QUIT_ON_COMPLETE = True
+    # Commandline script passed to blender, directory should be //tests/
+    UPDATER_MODULE_DIR = os.path.dirname(os.getcwd())
+    QUIT_ON_COMPLETE = True
 
 sys.path.append(UPDATER_MODULE_DIR)
 import addon_updater
@@ -64,168 +64,168 @@ import addon_updater
 
 class TestEngines(unittest.TestCase):
 
-	def test_gitlab(self):
-		"""Test the gitlab updater"""
+    def test_gitlab(self):
+        """Test the gitlab updater"""
 
-		updater = addon_updater.SingletonUpdater()
-		updater.engine = "GitLab"
-		updater.private_token = None
-		updater.user = "theduckcow"
-		updater.repo = "3645616"
-		updater.website = "https://gitlab.com/TheDuckCow/test-updater-gitlab"
+        updater = addon_updater.SingletonUpdater()
+        updater.engine = "GitLab"
+        updater.private_token = None
+        updater.user = "theduckcow"
+        updater.repo = "3645616"
+        updater.website = "https://gitlab.com/TheDuckCow/test-updater-gitlab"
 
-		# Check rate limits
-		# https://docs.gitlab.com/ee/api/README.html#rate-limits
+        # Check rate limits
+        # https://docs.gitlab.com/ee/api/README.html#rate-limits
 
-		self.run_engine_test(updater)
+        self.run_engine_test(updater)
 
-	def test_github(self):
-		"""Test the Github updater"""
+    def test_github(self):
+        """Test the Github updater"""
 
-		updater = addon_updater.SingletonUpdater()
-		updater.engine = "Github"
-		updater.private_token = None
-		updater.user = "cgcookie"
-		updater.repo = "blender-addon-updater"
-		updater.website = "https://github.com/CGCookie/blender-addon-updater"
+        updater = addon_updater.SingletonUpdater()
+        updater.engine = "Github"
+        updater.private_token = None
+        updater.user = "cgcookie"
+        updater.repo = "blender-addon-updater"
+        updater.website = "https://github.com/CGCookie/blender-addon-updater"
 
-		# Check rate limitations (command will show if local limit reached)
-		# curl "https://api.github.com/rate_limit"
-		# More info: https://developer.github.com/v3/rate_limit/
+        # Check rate limitations (command will show if local limit reached)
+        # curl "https://api.github.com/rate_limit"
+        # More info: https://developer.github.com/v3/rate_limit/
 
-		self.run_engine_test(updater)
+        self.run_engine_test(updater)
 
-	def test_bitbucket(self):
-		"""Test the Bitbucket updater"""
+    def test_bitbucket(self):
+        """Test the Bitbucket updater"""
 
-		updater = addon_updater.SingletonUpdater()
-		updater.engine = "Bitbucket"
-		updater.private_token = None
-		updater.user = "theduckcow"
-		updater.repo = "blender-addon-updater-bitbucket"
-		updater.website = "https://bitbucket.org/TheDuckCow/blender-addon-updater-bitbucket"
+        updater = addon_updater.SingletonUpdater()
+        updater.engine = "Bitbucket"
+        updater.private_token = None
+        updater.user = "theduckcow"
+        updater.repo = "blender-addon-updater-bitbucket"
+        updater.website = "https://bitbucket.org/TheDuckCow/blender-addon-updater-bitbucket"
 
-		# Check rate limitations
-		# https://confluence.atlassian.com/bitbucket/rate-limits-668173227.html
+        # Check rate limitations
+        # https://confluence.atlassian.com/bitbucket/rate-limits-668173227.html
 
-		self.run_engine_test(updater)
+        self.run_engine_test(updater)
 
-	def run_engine_test(self, updater):
-		"""Run a test for a single engine."""
+    def run_engine_test(self, updater):
+        """Run a test for a single engine."""
 
-		# Redefine where updating occurs within testing framework
-		os.path.join(UPDATER_MODULE_DIR, "")
-		updater._addon = "test_updater"
-		updater._addon_package = ""
-		updater._updater_path = os.path.join(UPDATER_MODULE_DIR, "test_updater")
-		updater._addon_root = UPDATER_MODULE_DIR
-		updater.verbose = False
+        # Redefine where updating occurs within testing framework
+        os.path.join(UPDATER_MODULE_DIR, "")
+        updater._addon = "test_updater"
+        updater._addon_package = ""
+        updater._updater_path = os.path.join(UPDATER_MODULE_DIR, "test_updater")
+        updater._addon_root = UPDATER_MODULE_DIR
+        updater.verbose = False
 
-		updater.current_version = (1, 0, 0)
-		updater.backup_current = False
-		updater.include_branches = True
-		updater.use_releases = False
+        updater.current_version = (1, 0, 0)
+        updater.backup_current = False
+        updater.include_branches = True
+        updater.use_releases = False
 
-		# Test raw API call
-		tag_url = updater.form_tags_url()
-		_ = updater.form_branch_url("master")
-		# branch_url = updater.form_branch_url("master")
-		# parsed_tag = updater._engine.parse_tags()
+        # Test raw API call
+        tag_url = updater.form_tags_url()
+        _ = updater.form_branch_url("master")
+        # branch_url = updater.form_branch_url("master")
+        # parsed_tag = updater._engine.parse_tags()
 
-		# verify ths raw request doesn't fail
-		res = updater.get_raw(tag_url)
-		self.assertIsNotNone(res)
-		self.assertNotEqual(res, "")
+        # verify ths raw request doesn't fail
+        res = updater.get_raw(tag_url)
+        self.assertIsNotNone(res)
+        self.assertNotEqual(res, "")
 
-		# verify and check output of parse request
-		res = updater.get_api(tag_url)
-		self.assertIsNotNone(res)
-		self.assertTrue(len(res) > 0)
+        # verify and check output of parse request
+        res = updater.get_api(tag_url)
+        self.assertIsNotNone(res)
+        self.assertTrue(len(res) > 0)
 
-		# Test the end to end get tag names request
-		tags = updater._get_tag_names()
-		self.assertTrue(len(tags) > 0)
-		# print("Found {} tags".format(len(tags)))
+        # Test the end to end get tag names request
+        tags = updater._get_tag_names()
+        self.assertTrue(len(tags) > 0)
+        # print("Found {} tags".format(len(tags)))
 
-		# Grab link to an archive (should be master for all)
-		link = updater.select_link(updater, updater._tags[0])
-		self.assertIsNotNone(link)
-		# print(link)
+        # Grab link to an archive (should be master for all)
+        link = updater.select_link(updater, updater._tags[0])
+        self.assertIsNotNone(link)
+        # print(link)
 
-		# Test downloading to the staging folder,
-		# clear folder first if needed
-		staged_master = updater.stage_repository(link)
-		self.assertTrue(staged_master)
+        # Test downloading to the staging folder,
+        # clear folder first if needed
+        staged_master = updater.stage_repository(link)
+        self.assertTrue(staged_master)
 
-		# now try downloading a non-master branch
-		link = updater.select_link(updater, updater._tags[1])
-		self.assertIsNotNone(link)
-		staged_tag = updater.stage_repository(link)
-		self.assertTrue(staged_tag)
+        # now try downloading a non-master branch
+        link = updater.select_link(updater, updater._tags[1])
+        self.assertIsNotNone(link)
+        staged_tag = updater.stage_repository(link)
+        self.assertTrue(staged_tag)
 
-		# Test the synchronous check function, knowing it should have an update
-		updater._update_ready = None
-		updater.check_for_update()
-		self.assertTrue(updater._update_ready)
+        # Test the synchronous check function, knowing it should have an update
+        updater._update_ready = None
+        updater.check_for_update()
+        self.assertTrue(updater._update_ready)
 
-		# Test the synchronous check function, knowing it should have no update
-		updater.current_version = (99, 0, 0)
-		updater._update_ready = None
-		updater.check_for_update()
-		self.assertFalse(updater._update_ready)
+        # Test the synchronous check function, knowing it should have no update
+        updater.current_version = (99, 0, 0)
+        updater._update_ready = None
+        updater.check_for_update()
+        self.assertFalse(updater._update_ready)
 
 
 class TestFunctions(unittest.TestCase):
-	"""Unit tests not dependent on specific updater engines.
+    """Unit tests not dependent on specific updater engines.
 
-	Test will run with the GitHub engine
+    Test will run with the GitHub engine
 
-	TODO, add:
-		# set_check_interval
-		# create_backup
-		# run_update
-		# restore_backup
-		# unpack_staged_zip
-		# deepMergeDirectory
-		# set_updater_json
-		# set_tag
-		# test with different min/max update versions set
-	"""
+    TODO, add:
+        # set_check_interval
+        # create_backup
+        # run_update
+        # restore_backup
+        # unpack_staged_zip
+        # deepMergeDirectory
+        # set_updater_json
+        # set_tag
+        # test with different min/max update versions set
+    """
 
-	def test_version_tuple_from_text(self):
-		"""Test tuple extraction examples"""
+    def test_version_tuple_from_text(self):
+        """Test tuple extraction examples"""
 
-		updater = addon_updater.SingletonUpdater()
-		updater.include_branches = False  # otherwise could treat as branch name
+        updater = addon_updater.SingletonUpdater()
+        updater.include_branches = False  # otherwise could treat as branch name
 
-		# structure of: input, expected
-		test_cases = [
-			["0.0.0", (0, 0, 0)],
-			["v0.0.0", (0, 0, 0)],
-			["v0.0", (0, 0)],
-			["v0.0 beta", (0, 0)],
-			["version 1,2,3 beta", (1, 2, 3)]
-		]
+        # structure of: input, expected
+        test_cases = [
+            ["0.0.0", (0, 0, 0)],
+            ["v0.0.0", (0, 0, 0)],
+            ["v0.0", (0, 0)],
+            ["v0.0 beta", (0, 0)],
+            ["version 1,2,3 beta", (1, 2, 3)]
+        ]
 
-		for case in test_cases:
-			res = updater.version_tuple_from_text(case[0])
-			self.assertEqual(res, case[1])
+        for case in test_cases:
+            res = updater.version_tuple_from_text(case[0])
+            self.assertEqual(res, case[1])
 
-	def test_reload_callback(self):
-		"""Test the reload function which disables and re-enables addon"""
-		updater = addon_updater.SingletonUpdater()
-		updater.auto_reload_post_update = True
-		updater._addon_package = "blender-addon-updater-github"  # test override
-		updater.reload_addon()  # assert no error
+    def test_reload_callback(self):
+        """Test the reload function which disables and re-enables addon"""
+        updater = addon_updater.SingletonUpdater()
+        updater.auto_reload_post_update = True
+        updater._addon_package = "blender-addon-updater-github"  # test override
+        updater.reload_addon()  # assert no error
 
 
 if __name__ == '__main__':
-	print("Running Updater Tests")
-	if QUIT_ON_COMPLETE:
-		# Running in command line, exclude blender startup args
-		test_args = (sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else [])
-		sys.argv = [os.path.basename(__file__)] + test_args
-		unittest.main(exit=QUIT_ON_COMPLETE, argv=sys.argv)
-	else:
-		# Running within blender UI script
-		unittest.main(exit=QUIT_ON_COMPLETE)
+    print("Running Updater Tests")
+    if QUIT_ON_COMPLETE:
+        # Running in command line, exclude blender startup args
+        test_args = (sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else [])
+        sys.argv = [os.path.basename(__file__)] + test_args
+        unittest.main(exit=QUIT_ON_COMPLETE, argv=sys.argv)
+    else:
+        # Running within blender UI script
+        unittest.main(exit=QUIT_ON_COMPLETE)

--- a/tests/addon_updater_test.py
+++ b/tests/addon_updater_test.py
@@ -67,7 +67,7 @@ class TestEngines(unittest.TestCase):
 	def test_gitlab(self):
 		"""Test the gitlab updater"""
 
-		updater = addon_updater.Singleton_updater()
+		updater = addon_updater.SingletonUpdater()
 		updater.engine = "GitLab"
 		updater.private_token = None
 		updater.user = "theduckcow"
@@ -82,7 +82,7 @@ class TestEngines(unittest.TestCase):
 	def test_github(self):
 		"""Test the Github updater"""
 
-		updater = addon_updater.Singleton_updater()
+		updater = addon_updater.SingletonUpdater()
 		updater.engine = "Github"
 		updater.private_token = None
 		updater.user = "cgcookie"
@@ -98,7 +98,7 @@ class TestEngines(unittest.TestCase):
 	def test_bitbucket(self):
 		"""Test the Bitbucket updater"""
 
-		updater = addon_updater.Singleton_updater()
+		updater = addon_updater.SingletonUpdater()
 		updater.engine = "Bitbucket"
 		updater.private_token = None
 		updater.user = "theduckcow"
@@ -195,7 +195,7 @@ class TestFunctions(unittest.TestCase):
 	def test_version_tuple_from_text(self):
 		"""Test tuple extraction examples"""
 
-		updater = addon_updater.Singleton_updater()
+		updater = addon_updater.SingletonUpdater()
 		updater.include_branches = False  # otherwise could treat as branch name
 
 		# structure of: input, expected
@@ -213,7 +213,7 @@ class TestFunctions(unittest.TestCase):
 
 	def test_reload_callback(self):
 		"""Test the reload function which disables and re-enables addon"""
-		updater = addon_updater.Singleton_updater()
+		updater = addon_updater.SingletonUpdater()
 		updater.auto_reload_post_update = True
 		updater._addon_package = "blender-addon-updater-github"  # test override
 		updater.reload_addon()  # assert no error


### PR DESCRIPTION
Apply pep8 formatting to code base
- Prefer pythonic style checks for expressions, such as is none
- Classes automatically inherit object, so remove explicit object per pep8 convention.
- Use bl_idname to apply Blender name convention rather than class, as pep doesn't like it

Note:
Made a backwards in compatible change by renaming `updater_intrval_minutes` to `updater_interval_minutes`.
- If you want I can revert that out to keep it backwards compatible for this version and do follow with minor/major version to denote that.
- Keep in and bump the version number to a full minor version
Open to whatever you feel is appropriate, but again most developers are copy-pasting as we talked about previously so not a huge fix to account for when upgrading.
