### PR TITLE
Clarify in README.md support for Blender > 2.80

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ Included in this repository is an example addon which is integrates the auto-upd
         )
 ```
 
-7) Add the draw call to any according panel to indicate there is an update by adding this line to the end of the panel or window: `addon_updater_ops.update_notice_box_ui()`
+7) If blender version > 2.80, add the decorator `@addon_updater_ops.make_annotations` before the class drawing the preference UI. As shown in the   sample demo addon's `DemoPreferences` class, located in the `__init__` file.
+
+8) Add the draw call to any according panel to indicate there is an update by adding this line to the end of the panel or window: `addon_updater_ops.update_notice_box_ui()`
   - Again make sure to import the Operator File if this panel is defined in a file other than the addon's `__init__.py` file.
   - Note that this function will only be called once per blender session, and will only do anything if auto-check is enabled, thus triggering a background check for update provided the interval of time has passed since the last check for update. This is safe to trigger from draw as it is launched in a background thread and will not hang blender.
 
-8) Ensure at least one [release or tag](https://help.github.com/articles/creating-releases/) exists on the GitHub repository
+9) Ensure at least one [release or tag](https://help.github.com/articles/creating-releases/) exists on the GitHub repository
   - As an alternative or in addition to using releases, the setting `updater.include_branches = True` in the `addon_updater_ops.py` register function allows you to update to specific git branches. You can then specify the list of branches for updating by using `updater.include_branche_list = ['branch','names']` for which the default is set to ['master']
   - If no releases are found, the user preferences button will always show "Update to Master" without doing any version checking
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Included in this repository is an example addon which is integrates the auto-upd
         )
 ```
 
-7) If blender version > 2.80, add the decorator `@addon_updater_ops.make_annotations` before the class drawing the preference UI. As shown in the   sample demo addon's `DemoPreferences` class, located in the `__init__` file.
+7) If Blender version > 2.80, add the decorator `@addon_updater_ops.make_annotations` before the class drawing the preference UI. As shown in the   sample demo addon's `DemoPreferences` class, located in the `__init__` file.
 
 8) Add the draw call to any according panel to indicate there is an update by adding this line to the end of the panel or window: `addon_updater_ops.update_notice_box_ui()`
   - Again make sure to import the Operator File if this panel is defined in a file other than the addon's `__init__.py` file.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ Included in this repository is an example addon which is integrates the auto-upd
         )
 ```
 
-7) If Blender version > 2.80, add the decorator `@addon_updater_ops.make_annotations` before the class drawing the preference UI. As shown in the   sample demo addon's `DemoPreferences` class, located in the `__init__` file.
+7) To support Blender version > 2.80, make one (not necessairly both) of these changes:
+
+    a. Add the decorator `@addon_updater_ops.make_annotations` before your addon's user preferences class ([see here](https://github.com/CGCookie/blender-addon-updater/blob/master/__init__.py#L76))
+
+    b. Call `make_annotations()`, passing your addon's user preferences class as an input, inside a register function ([see here](https://github.com/CGCookie/blender-addon-updater/blob/master/__init__.py#L152))
 
 8) Add the draw call to any according panel to indicate there is an update by adding this line to the end of the panel or window: `addon_updater_ops.update_notice_box_ui()`
   - Again make sure to import the Operator File if this panel is defined in a file other than the addon's `__init__.py` file.


### PR DESCRIPTION
#70 fixed issues with Blender 2.93, however as a new user following the README.md instructions, it wasn't obvious to add the decorator before the addon preference UI. Once I dug into the changes in #70 it was clear. 

This PR clarifies the usage of the decorator for versions of Blender > 2.80, by noting the decorator and urging the user to check the `__init__` file.